### PR TITLE
restores ios functionality

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -99,6 +99,8 @@ export default function App() {
 
     if (Platform.OS === 'android') {
       init();
+    } else {
+      setPermissionsGranted(true);
     }
   }, []);
 


### PR DESCRIPTION
Resolves https://github.com/stripe/stripe-terminal-react-native/issues/28 by fixing breakage caused in https://github.com/stripe/stripe-terminal-react-native/pull/4 by removing android permissions checks.

Before:
<img width="490" alt="Screen Shot 2022-01-27 at 11 02 44 AM" src="https://user-images.githubusercontent.com/30239207/151452202-196c09d8-40c3-40a0-8fd0-c51b2d18900a.png">

After:
<img width="490" alt="Screen Shot 2022-01-27 at 3 11 32 PM" src="https://user-images.githubusercontent.com/30239207/151452224-99da718d-ebce-4f18-8a4b-32898908579b.png">


e2e CI is also reflects this (still a bit sad)

output of ios after #4 is:
```
Payments
    ✕ Connect and disconnect (27415 ms)
    ✕ Install required update and connect (25588 ms)
    ✕ Change discovery method to bluetooth proximity (19336 ms)
    ✕ Change discovery method to Internet (19176 ms)
    ✕ Collect card payment (25503 ms)
    ✕ Store card via readReusableCard (25518 ms)
    ✕ Store card via SetupIntent (25543 ms)
    ✕ In-Person Refund failed due to unsupported country (25902 ms)
    ○ skipped Required update impossible due to low battery
```
This PR
```
FAIL  e2e/app.e2e.js (274.674 s)
  Payments
    ✓ Connect and disconnect (16586 ms)
    ✓ Install required update and connect (29065 ms)
    ✓ Change discovery method to bluetooth proximity (10071 ms)
    ✓ Change discovery method to Internet (10374 ms)
    ✓ Collect card payment (36987 ms)
    ✕ Store card via readReusableCard (36687 ms)
    ✕ Store card via SetupIntent (34853 ms)
    ✕ In-Person Refund failed due to unsupported country (49616 ms)
    ○ skipped Required update impossible due to low battery
```