### PR TITLE
Fix reader display name for physical BT devices

### DIFF
--- a/example/src/screens/DiscoverReadersScreen.tsx
+++ b/example/src/screens/DiscoverReadersScreen.tsx
@@ -74,6 +74,14 @@ export default function DiscoverReadersScreen() {
     },
   });
 
+  const getReaderDisplayName = (reader: Reader.Type) => {
+    if (reader?.simulated) {
+      return `SimulatorID - ${reader.deviceType}`;
+    }
+
+    return `${reader.id || reader.serialNumber} - ${reader.deviceType}`;
+  };
+
   const [selectedLocation, setSelectedLocation] = useState<Location>();
   const [selectedUpdatePlan, setSelectedUpdatePlan] =
     useState<Reader.SimulateUpdateType>('none');
@@ -236,7 +244,7 @@ export default function DiscoverReadersScreen() {
           <ListItem
             key={reader.serialNumber}
             onPress={() => handleConnectReader(reader.serialNumber)}
-            title={`${reader.id || 'SimulatorID'} - ${reader.deviceType}`}
+            title={getReaderDisplayName(reader)}
           />
         ))}
       </List>

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true
+  }
+}

--- a/src/types/Reader.ts
+++ b/src/types/Reader.ts
@@ -9,7 +9,7 @@ export namespace Reader {
       serialNumber: string;
       locationId?: string;
       deviceSoftwareVersion?: string;
-      simulated: boolean;
+      simulated?: boolean;
       availableUpdate?: SoftwareUpdate;
       ipAddress?: string;
       locationStatus: LocationStatus;


### PR DESCRIPTION
Fixes https://github.com/stripe/stripe-terminal-react-native/issues/29

BT hardware does not have an `id` so we're going to fall back to `serialNumber` when we have to. Also doesn't look like `simulated` is returned for hardware payloads so updated the type reference to reflect that.

Before           |  After
:-------------------------:|:-------------------------:
![IMG_2692](https://user-images.githubusercontent.com/30239207/152238279-ec368572-ee4b-4a90-bb4b-9cd871b8467b.jpeg) |  ![IMG_2690](https://user-images.githubusercontent.com/30239207/152238289-b896d4e5-b295-4fb0-a57e-0d928c0fc24f.jpeg)



