### PR TITLE
Better display of internet readers in discover

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -286,7 +286,7 @@ PODS:
     - React-Core
   - RNGestureHandler (1.10.3):
     - React-Core
-  - RNReanimated (2.3.1):
+  - RNReanimated (2.3.0):
     - DoubleConversion
     - FBLazyVector
     - FBReactNativeSpec
@@ -314,7 +314,7 @@ PODS:
     - React-RCTText
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNScreens (3.10.2):
+  - RNScreens (3.10.1):
     - React-Core
     - React-RCTImage
   - stripe-terminal-react-native (0.1.0):
@@ -484,8 +484,8 @@ SPEC CHECKSUMS:
   RNCMaskedView: 0e1bc4bfa8365eba5fbbb71e07fbdc0555249489
   RNCPicker: cb57c823d5ce8d2d0b5dfb45ad97b737260dc59e
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
-  RNReanimated: da3860204e5660c0dd66739936732197d359d753
-  RNScreens: d6da2b9e29cf523832c2542f47bf1287318b1868
+  RNReanimated: 569c269480a76e39196aa17a5df08ef1561db5ff
+  RNScreens: 522705f2e5c9d27efb17f24aceb2bf8335bc7b8e
   stripe-terminal-react-native: eac43a8062936d5e796e6a1132d196c83600b225
   StripeTerminal: da566fa62a4e7bbf0510dd27614f3087293cd79e
   Yoga: 32a18c0e845e185f4a2a66ec76e1fd1f958f22fa

--- a/example/ios/StripeTerminalReactNativeExample.xcodeproj/project.pbxproj
+++ b/example/ios/StripeTerminalReactNativeExample.xcodeproj/project.pbxproj
@@ -268,10 +268,11 @@
 				TargetAttributes = {
 					00E356ED1AD99517003FC87E = {
 						CreatedOnToolsVersion = 6.2;
+						DevelopmentTeam = 3G43CD28VV;
 						TestTargetID = 13B07F861A680F5B00A75B9A;
 					};
 					13B07F861A680F5B00A75B9A = {
-						DevelopmentTeam = PJL7DA2X5F;
+						DevelopmentTeam = 3G43CD28VV;
 						LastSwiftMigration = 1250;
 					};
 					2D02E47A1E0B4A5D006451C7 = {
@@ -524,6 +525,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				DEVELOPMENT_TEAM = 3G43CD28VV;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -548,6 +550,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COPY_PHASE_STRIP = NO;
+				DEVELOPMENT_TEAM = 3G43CD28VV;
 				INFOPLIST_FILE = StripeTerminalReactNativeExampleTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -569,7 +572,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = PJL7DA2X5F;
+				DEVELOPMENT_TEAM = 3G43CD28VV;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = StripeTerminalReactNativeExample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;

--- a/example/src/screens/DiscoverReadersScreen.tsx
+++ b/example/src/screens/DiscoverReadersScreen.tsx
@@ -74,14 +74,17 @@ export default function DiscoverReadersScreen() {
     },
   });
 
+  const isBTReader = (reader: Reader.Type) =>
+    ['stripeM2', 'chipper2X', 'chipper1X', 'wisePad3'].includes(
+      reader.deviceType
+    );
+
   const getReaderDisplayName = (reader: Reader.Type) => {
     if (reader?.simulated) {
       return `SimulatorID - ${reader.deviceType}`;
     }
 
-    return `${reader.label || reader.serialNumber} - ${reader.deviceType} - ${
-      reader.status
-    }`;
+    return `${reader?.label || reader?.serialNumber} - ${reader.deviceType}`;
   };
 
   const [selectedLocation, setSelectedLocation] = useState<Location>();
@@ -247,6 +250,7 @@ export default function DiscoverReadersScreen() {
             key={reader.serialNumber}
             onPress={() => handleConnectReader(reader.serialNumber)}
             title={getReaderDisplayName(reader)}
+            disabled={!isBTReader(reader) && reader.status === 'offline'}
           />
         ))}
       </List>


### PR DESCRIPTION
- offline readers are disabled
- use reader label instead of serial when available
- BT readers ignore disabled state as they always have `offline` set in the reader object
- BT readers use serial as they will not have labels assigned

<img src="https://user-images.githubusercontent.com/30239207/152570758-eacfd10c-a712-4bed-83a4-aa9082a5bec8.PNG" width="200"/>
<img src="https://user-images.githubusercontent.com/30239207/152570763-39afd4c8-38df-4d60-9e0d-4ef18619290b.PNG" width="200"/>

