### PR TITLE
comment out android specific api line

### DIFF
--- a/example/.env.example
+++ b/example/.env.example
@@ -8,4 +8,4 @@ API_URL=http://127.0.0.1:3002
 # The example app will default to API_URL if no specific API_URL_ANDROID is defined
 # This is helpful when you're working with the android emulator as it remaps the localhost
 # ip value (default is 10.0.2.2)
-API_URL_ANDROID=http://10.0.2.2:3002
+# API_URL_ANDROID=http://10.0.2.2:3002


### PR DESCRIPTION
This is doing more harm than good, commenting out by default so people only use it when they need to use the android emulator