### PR TITLE
even better template example url

### DIFF
--- a/example/.env.example
+++ b/example/.env.example
@@ -2,7 +2,9 @@
 STRIPE_PRIVATE_KEY=sk_test_xxx
 
 # Backend API URL
-API_URL=http://127.0.0.1:3002
+# Note: this should be an ip/url your mobile device can reach when the example
+# app is loaded onto it.
+API_URL=https://your-merchant-backend.com
 
 # Android Backend API URL.
 # The example app will default to API_URL if no specific API_URL_ANDROID is defined


### PR DESCRIPTION
Making the URL even more explicit, having localhost as the default winds up causing issues when devs start trying to load the example app on a physical device.