### PR TITLE
Android test context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,7 +323,7 @@ workflows:
             - install-dependencies
       - e2e-android:
           context:
-            - stripe-terminal-react-native-android-test # sets API_URL_ANDROID to allow the emulator to access the CI backend
+            - stripe-terminal-react-native-android-test # sets API_URL_ANDROID to allow the emulator to access the example app backend
           requires:
             - install-dependencies
       - e2e-ios:


### PR DESCRIPTION
`API_URL_ANDROID` should only be set for example app builds that intend to interact with the example backend whilst running on an emulator. Example app builds deployed to Firebase should use `API_URL` to hit the backend deployed to heroku.

* `API_URL_ANDROID` removed from CircleCI project wide env vars via UI
* New context created via CircleCI UI: `stripe-terminal-react-native-android-test`
   * sets `API_URL_ANDROID`
* Adds `stripe-terminal-react-native-android-test` context to `e2e-android` build job