### PR TITLE
Example app backend returns 404 errors as json

### DIFF
--- a/example/server/index.ts
+++ b/example/server/index.ts
@@ -22,15 +22,6 @@ const app = express();
 const port = process.env.PORT ? process.env.PORT : 3002;
 
 app.use(express.json());
-app.use(function (req, res, _) {
-  const url = `${req.protocol}://${req.get('host')}${req.originalUrl}`;
-  res.status(404).send(
-    res.json({
-      errorCode: '404',
-      errorMessage: `Route not found ${url}`,
-    })
-  );
-});
 
 expressWinston.requestWhitelist.push('body');
 expressWinston.responseWhitelist.push('body');
@@ -136,6 +127,17 @@ app.post(
     }
   }
 );
+
+// 404 error handler - this should always be the last route
+app.use(function (req, res, _) {
+  const url = `${req.protocol}://${req.get('host')}${req.originalUrl}`;
+  res.status(404).send(
+    res.json({
+      errorCode: '404',
+      errorMessage: `Route not found ${url}`,
+    })
+  );
+});
 
 app.listen(port, () => {
   console.log('Running on port ' + port);


### PR DESCRIPTION
The example apps attempt to parse errors as json. If this fails (express returns html by default) then the error is masked.