### PR TITLE
connect to last location if none is provided

### DIFF
--- a/example/src/screens/DiscoverReadersScreen.tsx
+++ b/example/src/screens/DiscoverReadersScreen.tsx
@@ -165,7 +165,7 @@ export default function DiscoverReadersScreen() {
 
     const { reader: connectedReader, error } = await connectBluetoothReader({
       reader,
-      locationId: selectedLocation?.id || reader.location.id,
+      locationId: selectedLocation?.id || reader?.location?.id,
     });
 
     if (error) {


### PR DESCRIPTION
pulls over a quality of life feature from iOS

fixes https://github.com/stripe/stripe-terminal-react-native/issues/106