### PR TITLE
Restarting heroku prior to deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -306,6 +306,10 @@ jobs:
       - attach_project
       - heroku/install
       - run:
+          name: Heroku - restart dynos
+          command: |
+              heroku restart -a $HEROKU_APP_NAME
+      - run:
           name: Heroku - set private key
           command: |
               heroku config:set STRIPE_PRIVATE_KEY=$STRIPE_PRIVATE_KEY -a $HEROKU_APP_NAME


### PR DESCRIPTION
Solves the intermittent "maximum concurrent builds for this account type" error