### PR TITLE
Added metadata property to enable Android SDK RN identification

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,1 +1,8 @@
-<manifest package="com.stripeterminalreactnative" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.stripeterminalreactnative">
+    <application>
+        <meta-data
+            android:name="com.stripe.stripeterminal.is_react_native"
+            android:value="true" />
+    </application>
+</manifest>


### PR DESCRIPTION
## Summary

* Adds metadata property to enable Android SDK RN identification

## Motivation

Allows embedded Android SDK to detect that its running within the RN SDK

## Testing

- [X] I tested this manually
- [ ] I added automated tests