### PR TITLE
Tell the iOS SDK that it's being driven by React Native

### DIFF
--- a/ios/StripeTerminalReactNative.swift
+++ b/ios/StripeTerminalReactNative.swift
@@ -1,4 +1,5 @@
 import StripeTerminal
+import Foundation
 
 enum ReactNativeConstants: String, CaseIterable {
     case UPDATE_DISCOVERED_READERS = "didUpdateDiscoveredReaders"
@@ -66,6 +67,10 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, BluetoothRe
         } else {
             Terminal.setTokenProvider(TokenProvider.shared)
             Terminal.shared.logLevel = logLevel
+        }
+
+        if Terminal.shared.responds(to: NSSelectorFromString("reportAsReactNativeSdk")) {
+            Terminal.shared.performSelector(inBackground: NSSelectorFromString("reportAsReactNativeSdk"), with: self)
         }
 
         resolve(["reader": connectedReader])


### PR DESCRIPTION
## Summary

Stacked on top of #241 - b01ebda is the only interesting commit
Counterpoint to https://github.com/stripe-ios/stripe-terminal-ios/pull/1621

Checks to see if the SCPTerminal singleton contains a `reportAsReactNativeSdk` method, and if so, calls it.

This method, when called, will cause the Terminal singleton to report that it's being driven by the React Native SDK to our internal analytics service.

## Motivation

Allow the embedded iOS SDK to report that it's running within the RN SDK

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
