### PR TITLE
fixing setReaderDisplay android mappings

### DIFF
--- a/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
@@ -360,7 +360,7 @@ internal fun mapToCartLineItem(cartLineItem: HashMap<*, *>): CartLineItem? {
     val quantity = cartLineItem["quantity"] as? Double ?: return null
     val amount = cartLineItem["amount"] as? Double ?: return null
 
-    return CartLineItem.Builder(displayName, amount.toInt(), quantity.toLong()).build()
+    return CartLineItem.Builder(displayName, quantity.toInt(), amount.toLong()).build()
 }
 
 internal fun mapFromRefund(refund: Refund): ReadableMap = nativeMapOf {

--- a/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
@@ -398,7 +398,7 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
         val currency = requireParam(params.getString("currency")) {
             "You must provide a currency value"
         }
-        val tax = requireParam(getInt(params, "total")?.toLong()) {
+        val tax = requireParam(getInt(params, "tax")?.toLong()) {
             "You must provide a tax value"
         }
         val total = requireParam(getInt(params, "total")?.toLong()) {

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -286,7 +286,7 @@ PODS:
     - React-Core
   - RNGestureHandler (1.10.3):
     - React-Core
-  - RNReanimated (2.3.1):
+  - RNReanimated (2.5.0):
     - DoubleConversion
     - FBLazyVector
     - FBReactNativeSpec
@@ -484,7 +484,7 @@ SPEC CHECKSUMS:
   RNCMaskedView: 0e1bc4bfa8365eba5fbbb71e07fbdc0555249489
   RNCPicker: cb57c823d5ce8d2d0b5dfb45ad97b737260dc59e
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
-  RNReanimated: da3860204e5660c0dd66739936732197d359d753
+  RNReanimated: ee33ab40fa252332a36aeed9d936801ed9700b24
   RNScreens: d6da2b9e29cf523832c2542f47bf1287318b1868
   stripe-terminal-react-native: eac43a8062936d5e796e6a1132d196c83600b225
   StripeTerminal: 2c7d261881b0039693a6ba30c00e1e6133e6d393

--- a/example/src/screens/DiscoverReadersScreen.tsx
+++ b/example/src/screens/DiscoverReadersScreen.tsx
@@ -249,7 +249,6 @@ export default function DiscoverReadersScreen() {
 
     const { reader: connectedReader, error } = await connectInternetReader({
       reader,
-      failIfInUse: true,
     });
 
     if (error) {

--- a/example/src/screens/HomeScreen.tsx
+++ b/example/src/screens/HomeScreen.tsx
@@ -45,6 +45,12 @@ export default function HomeScreen() {
           }}
         />
         <ListItem
+          title="Set Reader Display"
+          onPress={() => {
+            navigation.navigate('ReaderDisplayScreen');
+          }}
+        />
+        <ListItem
           title="Store card via readReusableCard"
           onPress={() => {
             navigation.navigate('ReadReusableCardScreen');

--- a/example/src/screens/ReaderDisplayScreen.tsx
+++ b/example/src/screens/ReaderDisplayScreen.tsx
@@ -1,40 +1,44 @@
 import React, { useState } from 'react';
-import { StyleSheet, TextInput, View } from 'react-native';
+import { ScrollView, Platform, StyleSheet, TextInput } from 'react-native';
+import List from '../components/List';
+import ListItem from '../components/ListItem';
 import { useStripeTerminal } from 'stripe-terminal-react-native';
 import { colors } from '../colors';
-import Button from '../components/Button';
 
 export default function ReaderDisplayScreen() {
   const { setReaderDisplay, clearReaderDisplay } = useStripeTerminal();
   const [cart, setCart] = useState<{
     currency?: string;
     tax?: string;
-    total?: string;
-  }>({ currency: 'usd', tax: '200', total: '5000' });
+    amount?: string;
+    itemDescription: string;
+  }>({
+    currency: 'usd',
+    tax: '200',
+    amount: '5000',
+    itemDescription: 'Red t-shirt',
+  });
 
   const _setCartDisplay = async () => {
     const { error } = await setReaderDisplay({
       currency: cart.currency!,
       tax: Number(cart.tax),
-      total: Number(cart.total),
+      total: Number(cart.amount) + Number(cart.tax),
       lineItems: [
         {
-          displayName: 'item 1',
-          quantity: 5,
-          amount: 500,
-        },
-        {
-          displayName: 'item 2',
-          quantity: 12,
-          amount: 1200,
+          displayName: cart.itemDescription,
+          quantity: 1,
+          amount: Number(cart.amount),
         },
       ],
     });
+
     if (error) {
       console.log('error', error);
-    } else {
-      console.log('setReaderDisplay success');
+      return;
     }
+
+    console.log('setReaderDisplay success');
   };
 
   const _clearReaderDisplay = async () => {
@@ -46,8 +50,22 @@ export default function ReaderDisplayScreen() {
   };
 
   return (
-    <View style={styles.container}>
-      <View>
+    <ScrollView
+      contentContainerStyle={styles.container}
+      keyboardShouldPersistTaps="always"
+    >
+      <List bolded={false} topSpacing={false} title="Item Description">
+        <TextInput
+          autoCapitalize="none"
+          placeholder="Item Descritption"
+          onChangeText={(value) =>
+            setCart((c) => ({ ...c, itemDescription: value }))
+          }
+          value={cart.itemDescription}
+          style={styles.input}
+        />
+      </List>
+      <List bolded={false} topSpacing={false} title="Currency">
         <TextInput
           autoCapitalize="none"
           placeholder="Currency"
@@ -55,6 +73,8 @@ export default function ReaderDisplayScreen() {
           value={cart.currency}
           style={styles.input}
         />
+      </List>
+      <List bolded={false} topSpacing={false} title="Tax Amount">
         <TextInput
           autoCapitalize="none"
           placeholder="Tax"
@@ -63,38 +83,33 @@ export default function ReaderDisplayScreen() {
           value={String(cart.tax)}
           style={styles.input}
         />
+      </List>
+      <List bolded={false} topSpacing={false} title="Charge Amount">
         <TextInput
           autoCapitalize="none"
           placeholder="Total"
-          onChangeText={(value) => setCart((c) => ({ ...c, total: value }))}
-          value={String(cart.total)}
+          onChangeText={(value) => setCart((c) => ({ ...c, amount: value }))}
+          value={String(cart.amount)}
           style={styles.input}
         />
-        <View style={styles.buttonWrapper}>
-          <Button
-            variant="primary"
-            title="Set reader display"
-            disabled={!cart.currency || !cart.tax || !cart.total}
-            onPress={_setCartDisplay}
-          />
-        </View>
-        <View style={styles.buttonWrapper}>
-          <Button
-            variant="primary"
-            title="Clear reader display"
-            onPress={_clearReaderDisplay}
-          />
-        </View>
-      </View>
-    </View>
+      </List>
+      <List bolded={false} topSpacing={false} title="Display Actions">
+        <ListItem
+          title="Set reader display"
+          disabled={!cart.currency || !cart.tax || !cart.amount}
+          onPress={_setCartDisplay}
+        />
+        <ListItem title="Clear reader display" onPress={_clearReaderDisplay} />
+      </List>
+    </ScrollView>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: colors.white,
+    backgroundColor: colors.light_gray,
     flex: 1,
-    padding: 22,
+    paddingVertical: 22,
   },
   discoveredWrapper: {
     height: 50,
@@ -118,9 +133,20 @@ const styles = StyleSheet.create({
   },
   input: {
     height: 44,
-    borderBottomColor: colors.slate,
-    borderBottomWidth: 1.5,
+    backgroundColor: colors.white,
     color: colors.dark_gray,
+    paddingLeft: 16,
     marginBottom: 12,
+    borderBottomColor: colors.gray,
+    ...Platform.select({
+      ios: {
+        borderBottomWidth: StyleSheet.hairlineWidth,
+      },
+      android: {
+        borderBottomWidth: 1,
+        borderBottomColor: `${colors.gray}66`,
+        color: colors.dark_gray,
+      },
+    }),
   },
 });

--- a/src/StripeTerminalSdk.tsx
+++ b/src/StripeTerminalSdk.tsx
@@ -99,7 +99,7 @@ type StripeTerminalSdkType = {
   // Cancel installing software update
   cancelInstallingUpdate(): Promise<void>;
   // Set text on a reader display
-  setReaderDisplay(card: Cart): Promise<{
+  setReaderDisplay(cart: Cart): Promise<{
     error?: StripeError;
   }>;
   // Clear reader display


### PR DESCRIPTION
## Summary
- Updates setReaderDisplay screen
- Adds menu item to go to reader display screen when device is connected
- Fixes incorrect mappings on android side for tax, amount, and quantity
- removes `failIfInUse` as default connect behavior
- adds ability to set line item description and brings setReaderDisplay screen up to parity with webpos


![setReaderDisp](https://user-images.githubusercontent.com/30239207/161844959-760c8a9f-f624-49cf-82af-31cbf9b5d836.png)


<!-- Simple summary of what was changed. -->

## Motivation
https://jira.corp.stripe.com/browse/TERMINAL-20940
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

## Testing
validated manually, works 🎉 
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [ ] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
