### PR TITLE
update avd to pixel / android 12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ commands:
         default: 'TestingAVD'
       platform_version:
         type: string
-        default: 'android-31'
+        default: 'android-30'
       logcat_grep:
         type: string
         default: 'com.example.stripeterminalreactnative'
@@ -155,7 +155,7 @@ commands:
       - android/start-emulator:
           avd-name: <<parameters.device_name>>
           no-window: true
-          restore-gradle-cache-prefix: v2a
+          restore-gradle-cache-prefix: v1a
           memory: 2048
           gpu: auto
           run-logcat: true


### PR DESCRIPTION
## Summary
Motivated by the older nexus / android 10 image really having issues with metro / react CLI, updating the avd that's set locally to something more recent and bumping the api used in circleCI
<!-- Simple summary of what was changed. -->

