### PR TITLE
Added protections against failed low battery updates

### DIFF
--- a/example/src/screens/UpdateReaderScreen.tsx
+++ b/example/src/screens/UpdateReaderScreen.tsx
@@ -1,6 +1,6 @@
 import { RouteProp, useNavigation, useRoute } from '@react-navigation/core';
 import React, { useEffect, useState } from 'react';
-import { Image, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Alert, Image, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useStripeTerminal } from 'stripe-terminal-react-native';
 import { colors } from '../colors';
 import icon from '../assets/icon.png';
@@ -22,11 +22,16 @@ export default function UpdateReaderScreen() {
     onDidFinishInstallingUpdate: ({ error }) => {
       if (error) {
         console.log(error.message);
-      } else {
-        params?.onDidUpdate();
+        Alert.alert(error.message);
         if (navigation.canGoBack()) {
           navigation.goBack();
         }
+        return;
+      }
+
+      params?.onDidUpdate();
+      if (navigation.canGoBack()) {
+        navigation.goBack();
       }
     },
   });
@@ -37,9 +42,13 @@ export default function UpdateReaderScreen() {
     });
 
     navigation.addListener('beforeRemove', async (e) => {
-      e.preventDefault();
-      await cancelInstallingUpdate();
-      navigation.dispatch(e.data.action);
+      try {
+        e.preventDefault();
+        await cancelInstallingUpdate();
+      } catch (ex) {
+      } finally {
+        navigation.dispatch(e.data.action);
+      }
     });
   }, [navigation, cancelInstallingUpdate]);
 


### PR DESCRIPTION
## Summary
Adding some try/catch logic so we don't try to cancel an already failed update. I believe this is causing force closes / crashes in the example app.
<!-- Simple summary of what was changed. -->

## Motivation

fixes https://github.com/stripe/stripe-terminal-react-native/issues/243
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

## Testing

going to bump to QA after the build as I don't have a dead / outdated reader and this isn't manifesting in iOS