### PR TITLE
iOS example app - Add ITSAppUsesNonExemptEncryption to info.plist

### DIFF
--- a/example/ios/StripeTerminalReactNativeExample/Info.plist
+++ b/example/ios/StripeTerminalReactNativeExample/Info.plist
@@ -10,6 +10,8 @@
 	<string>StripeTerminalReactNative Example</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIconName</key>
+	<string>AppIcon</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
@@ -24,6 +26,8 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>


### PR DESCRIPTION
## Summary

This lets us no longer have to set the encryption compliance within app store connect when uploading a new TestFlight build.

This is the same key/value pair that's in the iOS SDK example app.

The app icon part of the diff is an autogenerated change from Xcode.

## Motivation

Smoother TestFlight upload process

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

Sent an upload to testflight. Saw it pass from `Processing` to `Ready to Submit` without requiring that we specify how we use encryption.

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
