### PR TITLE
clear async storage on app mount in CI

### DIFF
--- a/example/src/Root.tsx
+++ b/example/src/Root.tsx
@@ -1,17 +1,33 @@
 import React, { useState, useCallback, useEffect } from 'react';
 
+import {
+  IS_CI,
+  // @ts-ignore
+} from '@env';
+
 import { StripeTerminalProvider } from 'stripe-terminal-react-native';
 import App from './App';
 import { AppContext, api } from './AppContext';
 import type { IAccount } from './types';
 import { Api } from './api/api';
-import { setSelectedAccount, getSelectedAccount } from './util/merchantStorage';
+import {
+  setSelectedAccount,
+  getSelectedAccount,
+  clearMerchantStorage,
+} from './util/merchantStorage';
 
 export default function Root() {
   const [account, setAccount] = useState<IAccount | null>(null);
   const [lastSuccessfulChargeId, setLastSuccessfulChargeId] = useState<
     string | null
   >(null);
+
+  useEffect(() => {
+    // var is a string in CircleCI
+    if (IS_CI === 'true') {
+      clearMerchantStorage();
+    }
+  }, []);
 
   const onSelectAccount = useCallback(
     async ({ selectedAccountKey }: { selectedAccountKey: string | null }) => {

--- a/example/src/util/merchantStorage.ts
+++ b/example/src/util/merchantStorage.ts
@@ -13,6 +13,8 @@ const SELECTED_ACCOUNT_KEY = '@rn_selected_example_account';
 const ACCOUNTS_KEY = '@rn_example_accounts';
 const DISCOVERY_KEY = '@rn_example_discovery';
 
+export const clearMerchantStorage = async () => AsyncStorage.clear();
+
 export const getStoredAccounts = async (): Promise<Array<IShortAccount>> => {
   const jsonValue = await AsyncStorage.getItem(ACCOUNTS_KEY);
   const accts = jsonValue ? JSON.parse(jsonValue) : [];


### PR DESCRIPTION
## Summary

What it says on the tin, realized during a CI flake that introducing discovery/merchant storage has resulted in our tests not being idempotent. This resets local storage on every e2e run resulting in less headaches and retries in CI.