### PR TITLE
Updated Terminal Android SDK to 2.9.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ def getExtOrIntegerDefault(name) {
     return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties['StripeTerminalReactNative_' + name]).toInteger()
 }
 
-def terminalAndroidSdkVersion = '2.8.1'
+def terminalAndroidSdkVersion = '2.9.0'
 
 android {
     compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')

--- a/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
@@ -79,14 +79,16 @@ internal fun mapFromNetworkStatus(status: Reader.NetworkStatus?): String {
 
 internal fun mapFromDeviceType(type: DeviceType): String {
     return when (type) {
+        DeviceType.CHIPPER_1X -> "chipper1X"
         DeviceType.CHIPPER_2X -> "chipper2X"
         DeviceType.COTS_DEVICE -> "cotsDevice"
+        DeviceType.ETNA -> "etna"
         DeviceType.STRIPE_M2 -> "stripeM2"
         DeviceType.UNKNOWN -> "unknown"
         DeviceType.VERIFONE_P400 -> "verifoneP400"
         DeviceType.WISEPAD_3 -> "wisePad3"
         DeviceType.WISEPOS_E -> "wisePosE"
-        DeviceType.ETNA -> "etna"
+        DeviceType.WISECUBE -> "wisecube"
     }
 }
 


### PR DESCRIPTION
## Summary

Pulled in the latest version of Terminal Android SDK

Addresses: https://jira.corp.stripe.com/browse/TERMINAL-20877

## Motivation

To resolve the USB crash issue caused by a bug in the Terminal Android SDK.

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [X] I tested this manually
- [ ] I added automated tests

