### PR TITLE
wire up refund command

### DIFF
--- a/ios/StripeTerminalReactNative.m
+++ b/ios/StripeTerminalReactNative.m
@@ -175,6 +175,11 @@ RCT_EXTERN_METHOD(
                   )
 
 RCT_EXTERN_METHOD(
+                  cancelCollectRefundPaymentMethod:(RCTPromiseResolveBlock)resolve
+                  rejecter: (RCTPromiseRejectBlock)reject
+                  )
+
+RCT_EXTERN_METHOD(
                   cancelReadReusableCard:(RCTPromiseResolveBlock)resolve
                   rejecter: (RCTPromiseRejectBlock)reject
                   )


### PR DESCRIPTION
## Summary

behold… stripe's newest iOS dev is on the case and fixing ios side bugs…

wired up a missing call sig for `collectRefundPaymentMethod` to resolve a QA reported bug with cancelling refunds