### PR TITLE
incremental and extended auth

### DIFF
--- a/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
@@ -7,8 +7,8 @@ import com.stripe.stripeterminal.log.LogLevel
 
 internal fun getInt(map: ReadableMap, key: String): Int? = if (map.hasKey(key)) map.getInt(key) else null
 
-internal fun getBoolean(map: ReadableMap, key: String): Boolean =
-    if (map.hasKey(key)) map.getBoolean(key) else false
+internal fun getBoolean(map: ReadableMap?, key: String): Boolean =
+    if (map?.hasKey(key) == true) map.getBoolean(key) else false
 
 internal fun putDoubleOrNull(mapTarget: WritableMap, key: String, value: Double?) {
     value?.let {

--- a/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
@@ -260,8 +260,10 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
         val customer = params.getString("customer")
         val transferGroup = params.getString("transferGroup")
         val metadata = params.getMap("metadata")
-        val extendedAuth = getBoolean(params, "requestExtendedAuthorization")
-        val incrementalAuth = getBoolean(params, "requestIncrementalAuthorizationSupport")
+        val paymentMethodOptions = params.getMap("paymentMethodOptions")
+        val extendedAuth = getBoolean(paymentMethodOptions, "requestExtendedAuthorization")
+        val incrementalAuth =
+            getBoolean(paymentMethodOptions, "requestIncrementalAuthorizationSupport")
 
         val paymentMethodTypes = paymentMethods?.toArrayList()?.mapNotNull {
             if (it is String) PaymentMethodType.valueOf(it.uppercase())

--- a/dev-app/src/screens/CollectCardPaymentScreen.tsx
+++ b/dev-app/src/screens/CollectCardPaymentScreen.tsx
@@ -160,9 +160,12 @@ export default function CollectCardPaymentScreen() {
         applicationFeeAmount: inputValues.applicationFeeAmount
           ? Number(inputValues.applicationFeeAmount)
           : undefined,
-        requestExtendedAuthorization: inputValues.requestExtendedAuthorization,
-        requestIncrementalAuthorizationSupport:
-          inputValues.requestIncrementalAuthorizationSupport,
+        paymentMethodOptions: {
+          requestExtendedAuthorization:
+            inputValues.requestExtendedAuthorization,
+          requestIncrementalAuthorizationSupport:
+            inputValues.requestIncrementalAuthorizationSupport,
+        },
       });
       paymentIntent = response.paymentIntent;
       paymentIntentError = response.error;

--- a/ios/StripeTerminalReactNative.swift
+++ b/ios/StripeTerminalReactNative.swift
@@ -299,8 +299,9 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, BluetoothRe
         let customer = params["customer"] as? String
         let transferGroup = params["transferGroup"] as? String
         let metadata = params["metadata"] as? [AnyHashable : Any]
-        let extendedAuth = params["requestExtendedAuthorization"] as? Bool ?? false
-        let incrementalAuth = params["requestIncrementalAuthorizationSupport"] as? Bool ?? false
+        let paymentMethodOptions = params["paymentMethodOptions"] as? [AnyHashable : Any] ?? [:]
+        let extendedAuth = paymentMethodOptions["requestExtendedAuthorization"] as? Bool ?? false
+        let incrementalAuth = paymentMethodOptions["requestIncrementalAuthorizationSupport"] as? Bool ?? false
 
 
         let paymentIntentParams = PaymentIntentParameters(amount: UInt(truncating: amount), currency: currency, paymentMethodTypes: paymentMethodTypes)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -164,12 +164,16 @@ export type CreatePaymentIntentParams = CreatePaymentIntentIOSParams & {
   customer?: string;
   transferGroup?: string;
   metadata?: Record<string, string>;
-  requestExtendedAuthorization?: boolean;
-  requestIncrementalAuthorizationSupport?: boolean;
+  paymentMethodOptions?: PaymentMethodOptions;
 };
 
 export type CreatePaymentIntentIOSParams = {
   paymentMethodTypes?: string[];
+};
+
+export type PaymentMethodOptions = {
+  requestExtendedAuthorization?: boolean;
+  requestIncrementalAuthorizationSupport?: boolean;
 };
 
 export type CollectPaymentMethodParams = {


### PR DESCRIPTION
## Summary

Wires up `requestExtendedAuthorization` and `requestIncrementalAuthorizationSupport` such that RN clients can create payment intents with these two parameters.

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [X] I tested this manually
- [ ] I added automated tests
