### PR TITLE
clear paymentIntents references

### DIFF
--- a/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
@@ -241,6 +241,7 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
     @ReactMethod
     @Suppress("unused")
     fun disconnectReader(promise: Promise) {
+        paymentIntents.clear()
         terminal.disconnectReader(NoOpCallback(promise))
     }
 
@@ -368,7 +369,7 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
         }
 
         terminal.processPayment(paymentIntent, RNPaymentIntentCallback(promise) {
-            paymentIntents[it.id] = it
+            paymentIntents.clear()
         })
     }
 
@@ -535,6 +536,7 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
     @Suppress("unused")
     fun clearCachedCredentials(promise: Promise) {
         terminal.clearCachedCredentials()
+        paymentIntents.clear()
         promise.resolve(WritableNativeMap())
     }
 

--- a/ios/StripeTerminalReactNative.swift
+++ b/ios/StripeTerminalReactNative.swift
@@ -273,6 +273,7 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, BluetoothRe
             if let error = error as NSError? {
                 resolve(Errors.createError(nsError: error))
             } else {
+                self.paymentIntents = [:]
                 resolve([:])
             }
         }
@@ -427,6 +428,7 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, BluetoothRe
                 resolve(Errors.createError(nsError: error))
             } else if let pi = pi {
                 let paymentIntent = Mappers.mapFromPaymentIntent(pi)
+                self.paymentIntents = [:]
                 resolve(["paymentIntent": paymentIntent])
             }
         }
@@ -666,6 +668,7 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, BluetoothRe
     @objc(clearCachedCredentials:rejecter:)
     func clearCachedCredentials(resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
         Terminal.shared.clearCachedCredentials()
+        self.paymentIntents = [:]
         resolve([:])
     }
 


### PR DESCRIPTION
## Summary

close #88 

Clear PaymentIntents references on native side. After certain scenarios we are sure that it's not needed anymore and we can clear it out.

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
