### PR TITLE
Removing jettier moshi ignore from android build

### DIFF
--- a/example-app/android/gradle.properties
+++ b/example-app/android/gradle.properties
@@ -25,8 +25,6 @@ android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
 
-android.jetifier.ignorelist=moshi-1.13.0.jar
-
 # Version of flipper SDK to use with React Native
 FLIPPER_VERSION=0.125.0
 


### PR DESCRIPTION
## Summary

Latest expo bumps our build version to no longer require this.

This should remove the last of our special sauce n our `ios` and `android` build folders.