### PR TITLE
Fix AppIcon listing in asset catalog

### DIFF
--- a/dev-app/ios/StripeTerminalReactNativeDevApp/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/dev-app/ios/StripeTerminalReactNativeDevApp/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -1,46 +1,55 @@
 {
   "images" : [
     {
+      "filename" : "Light App Icon With Badge Copy 4.png",
       "idiom" : "iphone",
       "scale" : "2x",
       "size" : "20x20"
     },
     {
+      "filename" : "Light App Icon With Badge Copy 4-1.png",
       "idiom" : "iphone",
       "scale" : "3x",
       "size" : "20x20"
     },
     {
+      "filename" : "Light App Icon With Badge Copy 4-2.png",
       "idiom" : "iphone",
       "scale" : "2x",
       "size" : "29x29"
     },
     {
+      "filename" : "Light App Icon With Badge Copy 4-3.png",
       "idiom" : "iphone",
       "scale" : "3x",
       "size" : "29x29"
     },
     {
+      "filename" : "Light App Icon With Badge Copy 4-4.png",
       "idiom" : "iphone",
       "scale" : "2x",
       "size" : "40x40"
     },
     {
+      "filename" : "Light App Icon With Badge Copy 4-5.png",
       "idiom" : "iphone",
       "scale" : "3x",
       "size" : "40x40"
     },
     {
+      "filename" : "Light App Icon With Badge Copy 4-6.png",
       "idiom" : "iphone",
       "scale" : "2x",
       "size" : "60x60"
     },
     {
+      "filename" : "Light App Icon With Badge Copy 4-7.png",
       "idiom" : "iphone",
       "scale" : "3x",
       "size" : "60x60"
     },
     {
+      "filename" : "Light App Icon With Badge Copy 4-8.png",
       "idiom" : "ios-marketing",
       "scale" : "1x",
       "size" : "1024x1024"


### PR DESCRIPTION
## Summary

Some automated script broke the AppIcon listing in Images.xcassets for the dev app, preventing us from uploading that dev app to testflight. This fixes that.

## Motivation

Unbreak QA deployment