### PR TITLE
remove stripeId from public interface

### DIFF
--- a/src/types/PaymentIntent.ts
+++ b/src/types/PaymentIntent.ts
@@ -8,7 +8,6 @@ export namespace PaymentIntent {
     created: string;
     currency: string;
     status: Status;
-    stripeId: string;
   }
 
   export type Status =


### PR DESCRIPTION
## Summary

Removes `stripeId` from public type interface, fixes https://github.com/stripe/stripe-terminal-react-native/issues/327