### PR TITLE
Fix iOS not announcing connection and payment status changes

### DIFF
--- a/ios/StripeTerminalReactNative.swift
+++ b/ios/StripeTerminalReactNative.swift
@@ -78,6 +78,8 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, BluetoothRe
             )
         }
 
+        Terminal.shared.delegate = self
+
         resolve(["reader": connectedReader])
     }
 


### PR DESCRIPTION
## Summary
The SCPTerminal.delegate is how connection status and payment status notifications are sent.

The delegate is optional though and just hadn't been set in the RN code. The callbacks were wired up, just missing the delegate setting during init.

<!-- Simple summary of what was changed. -->

## Motivation
fixes #333 

<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

connected, processed a payment, saw expected events with expected values in the logs:

```
 LOG  Running "StripeTerminalReactNativeDevApp" with {"rootTag":1,"initialProps":{}}
 LOG  StripeTerminal has been initialized properly
*snip*
 LOG  [Stripe terminal]: didChangeConnectionStatus connecting
 LOG  [Stripe terminal]: didChangeConnectionStatus connected
 LOG  [Stripe terminal]: didChangePaymentStatus ready
 LOG  Reader connected successfully {*snip*}
 LOG  [Stripe terminal]: didFinishDiscoveringReaders {"error": null}
 LOG  onFinishDiscoveringReaders success
 LOG  [Stripe terminal]: didChangePaymentStatus notReady
 LOG  [Stripe terminal]: didChangePaymentStatus ready
 LOG  [Stripe terminal]: didChangePaymentStatus waitingForInput
 LOG  [Stripe terminal]: didRequestReaderInput ["insertCard", "swipeCard", "tapCard"]
 LOG  [Stripe terminal]: didRequestReaderDisplayMessage removeCard
 LOG  [Stripe terminal]: didChangePaymentStatus ready
 LOG  [Stripe terminal]: didChangePaymentStatus processing
 LOG  [Stripe terminal]: didChangePaymentStatus ready
 LOG  [Stripe terminal]: Connected to the reader:  {*snip*}
 LOG  StripeTerminal has been initialized properly and connected to the reader {*snip*}
 LOG  [Stripe terminal]: didChangePaymentStatus notReady
 LOG  [Stripe terminal]: didChangeConnectionStatus notConnected
```

(before, all the `didChangeConnectionStatus` and `didChangePaymentStatus` were missing)

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
