### PR TITLE
fix redundant event emits

### DIFF
--- a/src/components/StripeTerminalProvider.tsx
+++ b/src/components/StripeTerminalProvider.tsx
@@ -90,6 +90,7 @@ export function StripeTerminalProvider({
   const didUpdateDiscoveredReaders = useCallback(
     ({ readers }: { readers: Reader.Type[] }) => {
       log('didUpdateDiscoveredReaders', readers);
+      emitter?.emit(UPDATE_DISCOVERED_READERS, readers);
     },
     [log]
   );
@@ -97,6 +98,7 @@ export function StripeTerminalProvider({
   const didFinishDiscoveringReaders = useCallback(
     ({ result }: EventResult<{ error?: StripeError }>) => {
       log('didFinishDiscoveringReaders', result);
+      emitter?.emit(FINISH_DISCOVERING_READERS, result.error);
     },
     [log]
   );
@@ -104,6 +106,7 @@ export function StripeTerminalProvider({
   const didReportUnexpectedReaderDisconnect = useCallback(
     ({ error }: { error?: StripeError }) => {
       log('didReportUnexpectedReaderDisconnect', error);
+      emitter?.emit(REPORT_UNEXPECTED_READER_DISCONNECT, error);
     },
     [log]
   );
@@ -111,6 +114,7 @@ export function StripeTerminalProvider({
   const didReportAvailableUpdate = useCallback(
     ({ result }: EventResult<Reader.SoftwareUpdate>) => {
       log('didReportAvailableUpdate', result);
+      emitter?.emit(REPORT_AVAILABLE_UPDATE, result);
     },
     [log]
   );
@@ -118,6 +122,7 @@ export function StripeTerminalProvider({
   const didStartInstallingUpdate = useCallback(
     ({ result }: EventResult<Reader.SoftwareUpdate>) => {
       log('didStartInstallingUpdate', result);
+      emitter?.emit(START_INSTALLING_UPDATE, result);
     },
     [log]
   );
@@ -125,6 +130,7 @@ export function StripeTerminalProvider({
   const didReportReaderSoftwareUpdateProgress = useCallback(
     ({ result }: EventResult<{ progress: string }>) => {
       log('didReportReaderSoftwareUpdateProgress', result);
+      emitter?.emit(REPORT_UPDATE_PROGRESS, result.progress);
     },
     [log]
   );
@@ -134,6 +140,7 @@ export function StripeTerminalProvider({
       result,
     }: EventResult<Reader.SoftwareUpdate | { error: StripeError }>) => {
       log('didFinishInstallingUpdate', result);
+      emitter?.emit(FINISH_INSTALLING_UPDATE, result);
     },
     [log]
   );
@@ -141,6 +148,7 @@ export function StripeTerminalProvider({
   const didRequestReaderInput = useCallback(
     ({ result }: EventResult<Reader.InputOptions[]>) => {
       log('didRequestReaderInput', result);
+      emitter?.emit(REQUEST_READER_INPUT, result);
     },
     [log]
   );
@@ -148,6 +156,7 @@ export function StripeTerminalProvider({
   const didRequestReaderDisplayMessage = useCallback(
     ({ result }: EventResult<Reader.DisplayMessage>) => {
       log('didRequestReaderDisplayMessage', result);
+      emitter?.emit(REQUEST_READER_DISPLAY_MESSAGE, result);
     },
     [log]
   );
@@ -155,6 +164,7 @@ export function StripeTerminalProvider({
   const didChangePaymentStatus = useCallback(
     ({ result }: EventResult<PaymentStatus>) => {
       log('didChangePaymentStatus', result);
+      emitter?.emit(CHANGE_PAYMENT_STATUS, result);
     },
     [log]
   );
@@ -162,6 +172,7 @@ export function StripeTerminalProvider({
   const didChangeConnectionStatus = useCallback(
     ({ result }: EventResult<Reader.ConnectionStatus>) => {
       log('didChangeConnectionStatus', result);
+      emitter?.emit(CHANGE_CONNECTION_STATUS, result);
     },
     [log]
   );

--- a/src/hooks/useStripeTerminal.tsx
+++ b/src/hooks/useStripeTerminal.tsx
@@ -151,17 +151,15 @@ export function useStripeTerminal(props?: Props) {
     ({ readers }: { readers: Reader.Type[] }) => {
       setDiscoveredReaders(readers);
       onUpdateDiscoveredReaders?.(readers);
-      emitter?.emit(UPDATE_DISCOVERED_READERS, readers);
     },
-    [setDiscoveredReaders, onUpdateDiscoveredReaders, emitter]
+    [setDiscoveredReaders, onUpdateDiscoveredReaders]
   );
 
   const didFinishDiscoveringReaders = useCallback(
     ({ result }: EventResult<{ error?: StripeError }>) => {
       onFinishDiscoveringReaders?.(result.error);
-      emitter?.emit(FINISH_DISCOVERING_READERS, result.error);
     },
-    [emitter, onFinishDiscoveringReaders]
+    [onFinishDiscoveringReaders]
   );
 
   const didReportUnexpectedReaderDisconnect = useCallback(
@@ -169,10 +167,8 @@ export function useStripeTerminal(props?: Props) {
       setConnectedReader(null);
       setDiscoveredReaders([]);
       onDidReportUnexpectedReaderDisconnect?.(error);
-      emitter?.emit(REPORT_UNEXPECTED_READER_DISCONNECT, error);
     },
     [
-      emitter,
       onDidReportUnexpectedReaderDisconnect,
       setConnectedReader,
       setDiscoveredReaders,
@@ -182,25 +178,22 @@ export function useStripeTerminal(props?: Props) {
   const didReportAvailableUpdate = useCallback(
     ({ result }: EventResult<Reader.SoftwareUpdate>) => {
       onDidReportAvailableUpdate?.(result);
-      emitter?.emit(REPORT_AVAILABLE_UPDATE, result);
     },
-    [emitter, onDidReportAvailableUpdate]
+    [onDidReportAvailableUpdate]
   );
 
   const didStartInstallingUpdate = useCallback(
     ({ result }: EventResult<Reader.SoftwareUpdate>) => {
       onDidStartInstallingUpdate?.(result);
-      emitter?.emit(START_INSTALLING_UPDATE, result);
     },
-    [emitter, onDidStartInstallingUpdate]
+    [onDidStartInstallingUpdate]
   );
 
   const didReportReaderSoftwareUpdateProgress = useCallback(
     ({ result }: EventResult<{ progress: string }>) => {
       onDidReportReaderSoftwareUpdateProgress?.(result.progress);
-      emitter?.emit(REPORT_UPDATE_PROGRESS, { progress: result.progress });
     },
-    [emitter, onDidReportReaderSoftwareUpdateProgress]
+    [onDidReportReaderSoftwareUpdateProgress]
   );
 
   const didFinishInstallingUpdate = useCallback(
@@ -214,51 +207,42 @@ export function useStripeTerminal(props?: Props) {
           update: undefined,
           error: error,
         });
-        emitter?.emit(FINISH_INSTALLING_UPDATE, { update: undefined, error });
       } else {
         onDidFinishInstallingUpdate?.({
           update: result as Reader.SoftwareUpdate,
           error: undefined,
         });
-        emitter?.emit(FINISH_INSTALLING_UPDATE, {
-          update: result,
-          error: undefined,
-        });
       }
     },
-    [emitter, onDidFinishInstallingUpdate]
+    [onDidFinishInstallingUpdate]
   );
 
   const didRequestReaderInput = useCallback(
     ({ result }: EventResult<Reader.InputOptions[]>) => {
       onDidRequestReaderInput?.(result);
-      emitter?.emit(REQUEST_READER_INPUT, result);
     },
-    [emitter, onDidRequestReaderInput]
+    [onDidRequestReaderInput]
   );
 
   const didRequestReaderDisplayMessage = useCallback(
     ({ result }: EventResult<Reader.DisplayMessage>) => {
       onDidRequestReaderDisplayMessage?.(result);
-      emitter?.emit(REQUEST_READER_DISPLAY_MESSAGE, result);
     },
-    [emitter, onDidRequestReaderDisplayMessage]
+    [onDidRequestReaderDisplayMessage]
   );
 
   const didChangePaymentStatus = useCallback(
     ({ result }: EventResult<PaymentStatus>) => {
       onDidChangePaymentStatus?.(result);
-      emitter?.emit(CHANGE_PAYMENT_STATUS, result);
     },
-    [emitter, onDidChangePaymentStatus]
+    [onDidChangePaymentStatus]
   );
 
   const didChangeConnectionStatus = useCallback(
     ({ result }: EventResult<Reader.ConnectionStatus>) => {
       onDidChangeConnectionStatus?.(result);
-      emitter?.emit(CHANGE_CONNECTION_STATUS, result);
     },
-    [emitter, onDidChangeConnectionStatus]
+    [onDidChangeConnectionStatus]
   );
 
   useListener(REPORT_AVAILABLE_UPDATE, didReportAvailableUpdate);


### PR DESCRIPTION
## Summary
Moved the event emit out of `useStripeTerminal` which can be mounted several times to `StripeTerminalProvider` which can only be mounted once, and will therefore only emit once
<!-- Simple summary of what was changed. -->

## Motivation
fixes https://github.com/stripe/stripe-terminal-react-native/issues/328
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

## Testing
Wired in events by hand and validated that events only fire once
```
LOG  onFinishDiscoveringReaders success
 LOG  UNSUBSCRIBING
 LOG  provider start installing update
 LOG  EMIT TEST didStartInstallingUpdateListener
 LOG  EMIT TEST finished installing update
```
