### PR TITLE
remove android cots and handoff deps

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -132,8 +132,6 @@ dependencies {
     api 'com.facebook.react:react-native:+'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "com.stripe:stripeterminal:$terminalAndroidSdkVersion"
-    implementation "com.stripe:stripeterminal-handoffclient:$terminalAndroidSdkVersion"
-    implementation "com.stripe:stripeterminal-localmobile:$terminalAndroidSdkVersion"
     implementation 'com.google.code.gson:gson:2.3.1'
     implementation 'com.squareup.okhttp3:okhttp:4.9.1'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.0'


### PR DESCRIPTION
## Summary
Removing cots and handoff deps as they're causing network security changes to client implementations
<!-- Simple summary of what was changed. -->

## Motivation
fixes https://github.com/stripe/stripe-terminal-react-native/issues/335
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

## Testing

CI passes, 🚢 