### PR TITLE
chenin and bric to codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jdivock-stripe @jil-stripe
+* @jdivock-stripe @bric-stripe @chenmin-stripe @jil-stripe


### PR DESCRIPTION
## Summary

<!-- Simple summary of what was changed. -->

Adding chenmin and bric as codeowners to cut down on bus factor (will remove jil in another week or so)