### PR TITLE
prevent calling discoverReaders if not completed

### DIFF
--- a/android/src/main/java/com/stripeterminalreactnative/Errors.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/Errors.kt
@@ -41,6 +41,16 @@ internal fun <T> requireCancelable(cancelable: T?, lazyMessage: () -> String): T
 }
 
 @Throws(TerminalException::class)
+internal fun <T> throwIfBusy(command: T?, lazyMessage: () -> String): Unit? {
+    return command?.run {
+        throw TerminalException(
+            TerminalErrorCode.READER_BUSY,
+            lazyMessage()
+        )
+    }
+}
+
+@Throws(TerminalException::class)
 internal fun <T> requireParam(input: T?, lazyMessage: () -> String): T {
     return input ?: throw TerminalException(
         TerminalErrorCode.INVALID_REQUIRED_PARAMETER,

--- a/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
@@ -151,7 +151,7 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
         val listener = RNDiscoveryListener(context) { discoveredReadersList = it }
 
         throwIfBusy(discoverCancelable) {
-            "Could not execute discoverReaders because the SDK is busy with another command: discoverReaders."
+            busyMessage("discoverReaders", "discoverReaders")
         }
 
         discoverCancelable = terminal.discoverReaders(
@@ -574,5 +574,9 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
         }
         toCancel.cancel(NoOpCallback(promise))
         block?.invoke()
+    }
+
+    private fun busyMessage(command: String, busyBy: String): String {
+        return  "Could not execute $command because the SDK is busy with another command: $busyBy."
     }
 }

--- a/ios/Errors.swift
+++ b/ios/Errors.swift
@@ -38,6 +38,10 @@ class Errors {
     }
 }
 
+func busyMessage(command: String, by busyCommand: String) -> String {
+    return "Could not execute \(command) because the SDK is busy with another command: \(busyCommand)."
+}
+
 extension ErrorCode.Code {
     var stringValue: String {
         switch self {

--- a/ios/StripeTerminalReactNative.swift
+++ b/ios/StripeTerminalReactNative.swift
@@ -181,6 +181,11 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, BluetoothRe
             discoveryMethod: Mappers.mapToDiscoveryMethod(discoveryMethod),
             simulated: simulated ?? false
         )
+        
+        guard discoverCancelable == nil else {
+            resolve(Errors.createError(code: ErrorCode.busy, message: "Could not execute discoverReaders because the SDK is busy with another command: discoverReaders."))
+            return
+        }
 
         self.discoverCancelable = Terminal.shared.discoverReaders(config, delegate: self) { error in
             if let error = error as NSError? {

--- a/ios/StripeTerminalReactNative.swift
+++ b/ios/StripeTerminalReactNative.swift
@@ -183,7 +183,8 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, BluetoothRe
         )
         
         guard discoverCancelable == nil else {
-            resolve(Errors.createError(code: ErrorCode.busy, message: "Could not execute discoverReaders because the SDK is busy with another command: discoverReaders."))
+            let message = busyMessage(command: "discoverReaders", by: "discoverReaders")
+            resolve(Errors.createError(code: ErrorCode.busy, message: message))
             return
         }
 


### PR DESCRIPTION
## Summary

resolves #349 

Prevent calling `discoverReaders` if the previous call is not completed or canceled to avoid losing reference of `cancelable`.

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
