### PR TITLE
fixing response logging

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -9,7 +9,6 @@ interface ObjectWithError {
 interface Trace {
   origin_role: string;
   origin_id: string;
-  type?: string;
   trace: {
     action_id: string;
     request_info: {
@@ -20,6 +19,8 @@ interface Trace {
     service: string;
     method: string;
     request: string;
+    response?: string;
+    exception?: string;
     version_info: {
       client_type: string;
       client_version: string;
@@ -211,7 +212,7 @@ export default class Logger {
         domain: 'Tracer',
         scope: 'e',
         event: trace?.trace?.method,
-        result: trace.type === 'success' ? 'OK' : 'ERROR',
+        result: trace?.trace?.exception ? 'ERROR' : 'OK',
       },
     }));
   }
@@ -256,7 +257,7 @@ export default class Logger {
       ...baseTraceObject,
       trace: {
         ...baseTraceObject.trace,
-        exception: response.error,
+        exception: JSON.stringify(response.error),
         response: JSON.stringify(response),
       },
     };


### PR DESCRIPTION
## Summary
What it says on the tin, issues with double parsing json to string and placing the payload in the wrong namespace .
<!-- Simple summary of what was changed. -->

## Motivation
Fix internal splunk logging
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

## Testing
validated by hand, logs showing up correctly in splunk now
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [ ] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
