### PR TITLE
beforeRemove listener cleanup

### DIFF
--- a/dev-app/src/screens/DiscoverReadersScreen.tsx
+++ b/dev-app/src/screens/DiscoverReadersScreen.tsx
@@ -106,6 +106,7 @@ export default function DiscoverReadersScreen() {
   const handleGoBack = useCallback(
     async (action: NavigationAction) => {
       await cancelDiscovering();
+
       if (navigation.canGoBack()) {
         navigation.dispatch(action);
       }
@@ -118,14 +119,23 @@ export default function DiscoverReadersScreen() {
       headerBackTitle: 'Cancel',
     });
 
-    navigation.addListener('beforeRemove', (e) => {
-      if (!discoveringLoading) {
+    const listener = navigation.addListener('beforeRemove', (e) => {
+      if (!discoveringLoading || !!connectingReader) {
         return;
       }
+
       e.preventDefault();
       handleGoBack(e.data.action);
     });
-  }, [navigation, cancelDiscovering, discoveringLoading, handleGoBack]);
+
+    return () => navigation.removeListener('beforeRemove', listener);
+  }, [
+    navigation,
+    cancelDiscovering,
+    discoveringLoading,
+    handleGoBack,
+    connectingReader,
+  ]);
 
   const handleDiscoverReaders = useCallback(async () => {
     setDiscoveringLoading(true);


### PR DESCRIPTION
## Summary

beforeRemove navigation listener needs to be cleaned up and it has to take into account `connectingReader` in order to determine if `cancelDiscovering` should be called. e.g. it should not be called when a reader has been connected already.


## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
