### PR TITLE
bumping underlying SDK versions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,7 +28,7 @@ def getExtOrIntegerDefault(name) {
     return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties['StripeTerminalReactNative_' + name]).toInteger()
 }
 
-def terminalAndroidSdkVersion = '2.12.0'
+def terminalAndroidSdkVersion = '2.11.0'
 def reactNativeSdkVersion = getVersionFromNpm()
 
 android {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,7 +28,7 @@ def getExtOrIntegerDefault(name) {
     return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties['StripeTerminalReactNative_' + name]).toInteger()
 }
 
-def terminalAndroidSdkVersion = '2.10.0'
+def terminalAndroidSdkVersion = '2.12.0'
 def reactNativeSdkVersion = getVersionFromNpm()
 
 android {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,6 +20,14 @@ buildscript {
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
+// required for Kotlin versions prior to 1.6.20
+// https://issuetracker.google.com/issues/217593040
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+    kotlinOptions {
+        freeCompilerArgs += ["-Xjvm-default=all"]
+    }
+}
+
 def getExtOrDefault(name) {
     return rootProject.ext.has(name) ? rootProject.ext.get(name) : project.properties['StripeTerminalReactNative_' + name]
 }
@@ -28,7 +36,7 @@ def getExtOrIntegerDefault(name) {
     return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties['StripeTerminalReactNative_' + name]).toInteger()
 }
 
-def terminalAndroidSdkVersion = '2.11.0'
+def terminalAndroidSdkVersion = '2.12.0'
 def reactNativeSdkVersion = getVersionFromNpm()
 
 android {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,7 +36,7 @@ def getExtOrIntegerDefault(name) {
     return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties['StripeTerminalReactNative_' + name]).toInteger()
 }
 
-def terminalAndroidSdkVersion = '2.12.0'
+def terminalAndroidSdkVersion = '2.11.0'
 def reactNativeSdkVersion = getVersionFromNpm()
 
 android {

--- a/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
@@ -7,6 +7,7 @@ import com.facebook.react.bridge.*
 import com.stripe.stripeterminal.Terminal
 import com.stripe.stripeterminal.TerminalApplicationDelegate.onCreate
 import com.stripe.stripeterminal.TerminalApplicationDelegate.onTrimMemory
+import com.stripe.stripeterminal.external.OnReaderTips
 import com.stripe.stripeterminal.external.callable.Cancelable
 import com.stripe.stripeterminal.external.callable.ReaderListenable
 import com.stripe.stripeterminal.external.models.*
@@ -335,6 +336,7 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
         })
     }
 
+    @OptIn(OnReaderTips::class)
     @ReactMethod
     @Suppress("unused")
     fun collectPaymentMethod(params: ReadableMap, promise: Promise) =

--- a/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
@@ -7,7 +7,6 @@ import com.facebook.react.bridge.*
 import com.stripe.stripeterminal.Terminal
 import com.stripe.stripeterminal.TerminalApplicationDelegate.onCreate
 import com.stripe.stripeterminal.TerminalApplicationDelegate.onTrimMemory
-import com.stripe.stripeterminal.external.OnReaderTips
 import com.stripe.stripeterminal.external.callable.Cancelable
 import com.stripe.stripeterminal.external.callable.ReaderListenable
 import com.stripe.stripeterminal.external.models.*
@@ -336,7 +335,6 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
         })
     }
 
-    @OptIn(OnReaderTips::class)
     @ReactMethod
     @Suppress("unused")
     fun collectPaymentMethod(params: ReadableMap, promise: Promise) =

--- a/dev-app/ios/Podfile.lock
+++ b/dev-app/ios/Podfile.lock
@@ -330,8 +330,8 @@ PODS:
     - React-RCTImage
   - stripe-terminal-react-native (0.0.1-beta.7):
     - React-Core
-    - StripeTerminal (= 2.9.0)
-  - StripeTerminal (2.9.0)
+    - StripeTerminal (= 2.11.0)
+  - StripeTerminal (2.11.0)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -505,8 +505,8 @@ SPEC CHECKSUMS:
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
   RNReanimated: 61f7efddd08550ffa5dee90021a157cd6e7c82fb
   RNScreens: 40a2cb40a02a609938137a1e0acfbf8fc9eebf19
-  stripe-terminal-react-native: cf58a249fd7d2a329100a05db7e92a1220b2a25d
-  StripeTerminal: 4df45e7dfc29f26a3406ac75070b88e3e0626f8e
+  stripe-terminal-react-native: 1d061cfb72e413a3b0287e1a03b89ed0524efe9b
+  StripeTerminal: 6644ad8f766cf7b8ea8381e922c208b7d8894468
   Yoga: 99652481fcd320aefa4a7ef90095b95acd181952
 
 PODFILE CHECKSUM: 584849009c1d877db9c0725b0a4a0bf94b889af9

--- a/stripe-terminal-react-native.podspec
+++ b/stripe-terminal-react-native.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "React-Core"
-  s.dependency "StripeTerminal" , "2.9.0"
+  s.dependency "StripeTerminal" , "2.11.0"
 end


### PR DESCRIPTION
## Summary
What it says on the tin

iOS: 2.9.0 -> 2.11.0
android: 2.10.0 -> 2.12.0

New features will be wired up for usage in SDK in a following release.
<!-- Simple summary of what was changed. -->

## Motivation
KTLO
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

## Testing

CI passes, 🚢 

## Documentation

Will publish change log on next npm release
