### PR TITLE
[android][discoverReaders] Fix promise resolution

### DIFF
--- a/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
@@ -1,8 +1,40 @@
 package com.stripeterminalreactnative
 
-import com.facebook.react.bridge.*
-import com.stripe.stripeterminal.external.models.*
+import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableArray
+import com.facebook.react.bridge.WritableMap
+import com.stripe.stripeterminal.external.models.Address
+import com.stripe.stripeterminal.external.models.CardDetails
+import com.stripe.stripeterminal.external.models.CardPresentDetails
+import com.stripe.stripeterminal.external.models.CartLineItem
+import com.stripe.stripeterminal.external.models.Charge
+import com.stripe.stripeterminal.external.models.ConnectionStatus
+import com.stripe.stripeterminal.external.models.DeviceType
+import com.stripe.stripeterminal.external.models.DiscoveryMethod
+import com.stripe.stripeterminal.external.models.Location
+import com.stripe.stripeterminal.external.models.LocationStatus
+import com.stripe.stripeterminal.external.models.PaymentIntent
+import com.stripe.stripeterminal.external.models.PaymentIntentStatus
+import com.stripe.stripeterminal.external.models.PaymentMethod
+import com.stripe.stripeterminal.external.models.PaymentMethodDetails
+import com.stripe.stripeterminal.external.models.PaymentStatus
+import com.stripe.stripeterminal.external.models.Reader
+import com.stripe.stripeterminal.external.models.ReaderDisplayMessage
+import com.stripe.stripeterminal.external.models.ReaderEvent
+import com.stripe.stripeterminal.external.models.ReaderInputOptions
 import com.stripe.stripeterminal.external.models.ReaderInputOptions.ReaderInputOption
+import com.stripe.stripeterminal.external.models.ReaderSoftwareUpdate
+import com.stripe.stripeterminal.external.models.ReceiptDetails
+import com.stripe.stripeterminal.external.models.Refund
+import com.stripe.stripeterminal.external.models.SetupAttempt
+import com.stripe.stripeterminal.external.models.SetupAttemptStatus
+import com.stripe.stripeterminal.external.models.SetupIntent
+import com.stripe.stripeterminal.external.models.SetupIntentCardPresentDetails
+import com.stripe.stripeterminal.external.models.SetupIntentPaymentMethodDetails
+import com.stripe.stripeterminal.external.models.SetupIntentStatus
+import com.stripe.stripeterminal.external.models.SetupIntentUsage
+import com.stripe.stripeterminal.external.models.SimulateReaderUpdate
 import com.stripe.stripeterminal.log.LogLevel
 
 internal fun getInt(map: ReadableMap, key: String): Int? = if (map.hasKey(key)) map.getInt(key) else null

--- a/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
@@ -59,13 +59,13 @@ internal fun putIntOrNull(mapTarget: WritableMap, key: String, value: Int?) {
 }
 
 internal fun nativeMapOf(block: WritableMap.() -> Unit = {}): WritableMap {
-    return WritableNativeMap().apply {
+    return NativeTypeFactory.writableNativeMap().apply {
         block()
     }
 }
 
 internal fun nativeArrayOf(block: WritableArray.() -> Unit = {}): WritableArray {
-    return WritableNativeArray().apply {
+    return NativeTypeFactory.writableNativeArray().apply {
         block()
     }
 }

--- a/android/src/main/java/com/stripeterminalreactnative/NativeTypeFactory.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/NativeTypeFactory.kt
@@ -1,0 +1,18 @@
+package com.stripeterminalreactnative
+
+import com.facebook.react.bridge.WritableArray
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.bridge.WritableNativeArray
+import com.facebook.react.bridge.WritableNativeMap
+
+/**
+ * Factory abstraction layer to make testing easier
+ *
+ * Native types like [WritableNativeMap] may have an Android OS dependency on, for example,
+ * [android.os.SystemClock.uptimeMillis] which can be challenging to mock.
+ */
+object NativeTypeFactory {
+    fun writableNativeMap(): WritableMap = WritableNativeMap()
+
+    fun writableNativeArray(): WritableArray = WritableNativeArray()
+}

--- a/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
@@ -168,7 +168,11 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
             "Unknown discoveryMethod: $discoveryMethodParam"
         }
 
-        val listener = RNDiscoveryListener(context) { discoveredReadersList = it }
+        val listener = RNDiscoveryListener(
+            context,
+            promise,
+            { discoveredReadersList = it }
+        )
 
         throwIfBusy(discoverCancelable) {
             busyMessage("discoverReaders", "discoverReaders")

--- a/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
@@ -3,13 +3,35 @@ package com.stripeterminalreactnative
 import android.app.Application
 import android.content.ComponentCallbacks2
 import android.content.res.Configuration
-import com.facebook.react.bridge.*
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.UiThreadUtil
 import com.stripe.stripeterminal.Terminal
 import com.stripe.stripeterminal.TerminalApplicationDelegate.onCreate
 import com.stripe.stripeterminal.TerminalApplicationDelegate.onTrimMemory
 import com.stripe.stripeterminal.external.callable.Cancelable
 import com.stripe.stripeterminal.external.callable.ReaderListenable
-import com.stripe.stripeterminal.external.models.*
+import com.stripe.stripeterminal.external.models.CardPresentParameters
+import com.stripe.stripeterminal.external.models.Cart
+import com.stripe.stripeterminal.external.models.CollectConfiguration
+import com.stripe.stripeterminal.external.models.DiscoveryConfiguration
+import com.stripe.stripeterminal.external.models.DiscoveryMethod
+import com.stripe.stripeterminal.external.models.ListLocationsParameters
+import com.stripe.stripeterminal.external.models.PaymentIntent
+import com.stripe.stripeterminal.external.models.PaymentIntentParameters
+import com.stripe.stripeterminal.external.models.PaymentMethodOptionsParameters
+import com.stripe.stripeterminal.external.models.PaymentMethodType
+import com.stripe.stripeterminal.external.models.ReadReusableCardParameters
+import com.stripe.stripeterminal.external.models.Reader
+import com.stripe.stripeterminal.external.models.RefundParameters
+import com.stripe.stripeterminal.external.models.SetupIntent
+import com.stripe.stripeterminal.external.models.SetupIntentCancellationParameters
+import com.stripe.stripeterminal.external.models.SetupIntentParameters
+import com.stripe.stripeterminal.external.models.SimulatedCard
+import com.stripe.stripeterminal.external.models.SimulatorConfiguration
 import com.stripeterminalreactnative.callback.NoOpCallback
 import com.stripeterminalreactnative.callback.RNLocationListCallback
 import com.stripeterminalreactnative.callback.RNPaymentIntentCallback
@@ -25,7 +47,6 @@ import com.stripeterminalreactnative.listener.RNUsbReaderListener
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlin.collections.HashMap
 
 
 class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :

--- a/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
@@ -171,7 +171,8 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
         val listener = RNDiscoveryListener(
             context,
             promise,
-            { discoveredReadersList = it }
+            { discoveredReadersList = it },
+            { discoverCancelable = null }
         )
 
         throwIfBusy(discoverCancelable) {

--- a/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
@@ -372,9 +372,11 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
                 "There is no associated paymentIntent with id $paymentIntentId"
             }
 
-            val config = if (params.hasKey("skipTipping")) {
-                CollectConfiguration(skipTipping = getBoolean(params, "skipTipping"))
-            } else null
+            val configBuilder = CollectConfiguration.Builder()
+            if (params.hasKey("skipTipping")) {
+                configBuilder.skipTipping = getBoolean(params, "skipTipping")
+            }
+            val config = configBuilder.build()
 
             collectPaymentMethodCancelable = terminal.collectPaymentMethod(
                 paymentIntent,

--- a/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
@@ -101,7 +101,7 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
                 tokenProvider,
                 RNTerminalListener(context)
             )
-            WritableNativeMap()
+            NativeTypeFactory.writableNativeMap()
         } else {
             nativeMapOf {
                 terminal.connectedReader?.let {
@@ -135,7 +135,7 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
     fun simulateReaderUpdate(update: String, promise: Promise) {
         val updateMapped = mapFromSimulateReaderUpdate(update)
         terminal.simulatorConfiguration = SimulatorConfiguration(updateMapped)
-        promise.resolve(WritableNativeMap())
+        promise.resolve(NativeTypeFactory.writableNativeMap())
     }
 
     @ReactMethod
@@ -145,7 +145,7 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
             terminal.simulatorConfiguration.update,
             SimulatedCard(testCardNumber = cardNumber)
         )
-        promise.resolve(WritableNativeMap())
+        promise.resolve(NativeTypeFactory.writableNativeMap())
     }
 
     @ReactMethod
@@ -468,7 +468,7 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
     @Suppress("unused")
     fun installAvailableUpdate(promise: Promise) {
         terminal.installAvailableUpdate()
-        promise.resolve(WritableNativeMap())
+        promise.resolve(NativeTypeFactory.writableNativeMap())
     }
 
     @ReactMethod
@@ -491,7 +491,7 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
         }
 
         val cartLineItems =
-            mapToCartLineItems(params.getArray("lineItems") ?: WritableNativeArray())
+            mapToCartLineItems(params.getArray("lineItems") ?: NativeTypeFactory.writableNativeArray())
 
         val cart = Cart.Builder(
             currency = currency,
@@ -562,7 +562,7 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
     fun clearCachedCredentials(promise: Promise) {
         terminal.clearCachedCredentials()
         paymentIntents.clear()
-        promise.resolve(WritableNativeMap())
+        promise.resolve(NativeTypeFactory.writableNativeMap())
     }
 
     @ReactMethod

--- a/android/src/main/java/com/stripeterminalreactnative/callback/NoOpCallback.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/callback/NoOpCallback.kt
@@ -7,7 +7,7 @@ import com.stripe.stripeterminal.external.models.TerminalException
 import com.stripeterminalreactnative.NativeTypeFactory
 import com.stripeterminalreactnative.createError
 
-internal class NoOpCallback(private val promise: Promise) : Callback {
+internal open class NoOpCallback(private val promise: Promise) : Callback {
     override fun onSuccess() {
         promise.resolve(NativeTypeFactory.writableNativeMap())
     }

--- a/android/src/main/java/com/stripeterminalreactnative/callback/NoOpCallback.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/callback/NoOpCallback.kt
@@ -4,11 +4,12 @@ import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.WritableNativeMap
 import com.stripe.stripeterminal.external.callable.Callback
 import com.stripe.stripeterminal.external.models.TerminalException
+import com.stripeterminalreactnative.NativeTypeFactory
 import com.stripeterminalreactnative.createError
 
 internal class NoOpCallback(private val promise: Promise) : Callback {
     override fun onSuccess() {
-        promise.resolve(WritableNativeMap())
+        promise.resolve(NativeTypeFactory.writableNativeMap())
     }
 
     override fun onFailure(e: TerminalException) {

--- a/android/src/main/java/com/stripeterminalreactnative/listener/RNDiscoveryListener.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/listener/RNDiscoveryListener.kt
@@ -16,6 +16,7 @@ internal class RNDiscoveryListener(
     private val context: ReactApplicationContext,
     promise: Promise,
     private val onDiscoveredReaders: (readers: List<Reader>) -> Unit,
+    private val onComplete: () -> Unit,
 ) : DiscoveryListener, NoOpCallback(promise) {
 
     override fun onUpdateDiscoveredReaders(readers: List<Reader>) {
@@ -30,6 +31,7 @@ internal class RNDiscoveryListener(
         context.sendEvent(ReactNativeConstants.FINISH_DISCOVERING_READERS.listenerName) {
             putMap("result", nativeMapOf())
         }
+        onComplete()
     }
 
     override fun onFailure(e: TerminalException) {
@@ -37,5 +39,6 @@ internal class RNDiscoveryListener(
         context.sendEvent(ReactNativeConstants.FINISH_DISCOVERING_READERS.listenerName) {
             putMap("result", createError(e))
         }
+        onComplete()
     }
 }

--- a/android/src/main/java/com/stripeterminalreactnative/listener/RNDiscoveryListener.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/listener/RNDiscoveryListener.kt
@@ -1,20 +1,22 @@
 package com.stripeterminalreactnative.listener
 
+import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
-import com.stripe.stripeterminal.external.callable.Callback
 import com.stripe.stripeterminal.external.callable.DiscoveryListener
 import com.stripe.stripeterminal.external.models.Reader
 import com.stripe.stripeterminal.external.models.TerminalException
 import com.stripeterminalreactnative.ReactExtensions.sendEvent
 import com.stripeterminalreactnative.ReactNativeConstants
+import com.stripeterminalreactnative.callback.NoOpCallback
 import com.stripeterminalreactnative.createError
 import com.stripeterminalreactnative.mapFromReaders
 import com.stripeterminalreactnative.nativeMapOf
 
-class RNDiscoveryListener(
+internal class RNDiscoveryListener(
     private val context: ReactApplicationContext,
+    promise: Promise,
     private val onDiscoveredReaders: (readers: List<Reader>) -> Unit,
-) : DiscoveryListener, Callback {
+) : DiscoveryListener, NoOpCallback(promise) {
 
     override fun onUpdateDiscoveredReaders(readers: List<Reader>) {
         onDiscoveredReaders(readers)
@@ -24,12 +26,14 @@ class RNDiscoveryListener(
     }
 
     override fun onSuccess() {
+        super.onSuccess()
         context.sendEvent(ReactNativeConstants.FINISH_DISCOVERING_READERS.listenerName) {
             putMap("result", nativeMapOf())
         }
     }
 
     override fun onFailure(e: TerminalException) {
+        super.onFailure(e)
         context.sendEvent(ReactNativeConstants.FINISH_DISCOVERING_READERS.listenerName) {
             putMap("result", createError(e))
         }

--- a/android/src/test/java/com/stripeterminalreactnative/listener/RNBluetoothReaderListenerTest.kt
+++ b/android/src/test/java/com/stripeterminalreactnative/listener/RNBluetoothReaderListenerTest.kt
@@ -25,7 +25,7 @@ import org.junit.ClassRule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import java.util.*
+import java.util.Date
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 

--- a/android/src/test/java/com/stripeterminalreactnative/listener/RNDiscoveryListenerTest.kt
+++ b/android/src/test/java/com/stripeterminalreactnative/listener/RNDiscoveryListenerTest.kt
@@ -41,15 +41,18 @@ class RNDiscoveryListenerTest {
     fun `should send onUpdateDiscoveredReaders event`() {
         val mockPromise = mockk<Promise>()
         val mockOnDiscoveredReaders = mockk<(List<Reader>) -> Unit>(relaxed = true)
+        val mockOnComplete = mockk<() -> Unit>()
         RNDiscoveryListener(
             context,
             mockPromise,
-            mockOnDiscoveredReaders
+            mockOnDiscoveredReaders,
+            mockOnComplete
         ).onUpdateDiscoveredReaders(readers)
 
         verify(exactly = 0) { mockPromise.resolve(any()) }
         verify(exactly = 1) { mockOnDiscoveredReaders.invoke(readers) }
         verify(exactly = 1) { context.sendEvent(UPDATE_DISCOVERED_READERS.listenerName, any()) }
+        verify(exactly = 0) { mockOnComplete.invoke() }
 
         assertTrue(typeReplacer.sendEventSlot.captured.hasValue("readers"))
     }
@@ -58,10 +61,12 @@ class RNDiscoveryListenerTest {
     fun `should send onSuccess event`() = mockkObject(NativeTypeFactory) {
         every { NativeTypeFactory.writableNativeMap() } returns mockk()
         val mockPromise = mockk<Promise>(relaxed = true)
+        val mockOnComplete = mockk<() -> Unit>(relaxed = true)
         RNDiscoveryListener(
             context,
             mockPromise,
-            mockk(relaxed = true)
+            mockk(relaxed = true),
+            mockOnComplete
         ).onSuccess()
 
         verify(exactly = 1) { mockPromise.resolve(any()) }
@@ -71,6 +76,7 @@ class RNDiscoveryListenerTest {
                 any()
             )
         }
+        verify(exactly = 1) { mockOnComplete.invoke() }
 
         assertTrue(typeReplacer.sendEventSlot.captured.hasEmptyResult())
     }
@@ -79,10 +85,12 @@ class RNDiscoveryListenerTest {
     fun `should send onFailure event`() = mockkObject(NativeTypeFactory) {
         every { NativeTypeFactory.writableNativeMap() } returns mockk()
         val mockPromise = mockk<Promise>(relaxed = true)
-        RNDiscoveryListener(context, mockPromise, mockk()).onFailure(EXCEPTION)
+        val mockOnComplete = mockk<() -> Unit>(relaxed = true)
+        RNDiscoveryListener(context, mockPromise, mockk(), mockOnComplete).onFailure(EXCEPTION)
 
         verify(exactly = 1) { mockPromise.resolve(any()) }
         verify(exactly = 1) { context.sendEvent(FINISH_DISCOVERING_READERS.listenerName, any()) }
+        verify(exactly = 1) { mockOnComplete.invoke() }
 
         assertTrue(typeReplacer.sendEventSlot.captured.hasError())
     }

--- a/android/src/test/java/com/stripeterminalreactnative/listener/RNDiscoveryListenerTest.kt
+++ b/android/src/test/java/com/stripeterminalreactnative/listener/RNDiscoveryListenerTest.kt
@@ -1,9 +1,11 @@
 package com.stripeterminalreactnative.listener
 
+import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.stripe.stripeterminal.external.models.Reader
 import com.stripe.stripeterminal.external.models.TerminalException
 import com.stripe.stripeterminal.external.models.TerminalException.TerminalErrorCode
+import com.stripeterminalreactnative.NativeTypeFactory
 import com.stripeterminalreactnative.ReactExtensions.sendEvent
 import com.stripeterminalreactnative.ReactNativeConstants.FINISH_DISCOVERING_READERS
 import com.stripeterminalreactnative.ReactNativeConstants.UPDATE_DISCOVERED_READERS
@@ -11,7 +13,9 @@ import com.stripeterminalreactnative.ReactNativeTypeReplacementRule
 import com.stripeterminalreactnative.hasEmptyResult
 import com.stripeterminalreactnative.hasError
 import com.stripeterminalreactnative.hasValue
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
 import io.mockk.verify
 import org.junit.ClassRule
 import org.junit.Test
@@ -35,9 +39,15 @@ class RNDiscoveryListenerTest {
 
     @Test
     fun `should send onUpdateDiscoveredReaders event`() {
+        val mockPromise = mockk<Promise>()
         val mockOnDiscoveredReaders = mockk<(List<Reader>) -> Unit>(relaxed = true)
-        RNDiscoveryListener(context, mockOnDiscoveredReaders).onUpdateDiscoveredReaders(readers)
+        RNDiscoveryListener(
+            context,
+            mockPromise,
+            mockOnDiscoveredReaders
+        ).onUpdateDiscoveredReaders(readers)
 
+        verify(exactly = 0) { mockPromise.resolve(any()) }
         verify(exactly = 1) { mockOnDiscoveredReaders.invoke(readers) }
         verify(exactly = 1) { context.sendEvent(UPDATE_DISCOVERED_READERS.listenerName, any()) }
 
@@ -45,18 +55,33 @@ class RNDiscoveryListenerTest {
     }
 
     @Test
-    fun `should send onSuccess event`() {
-        RNDiscoveryListener(context, mockk()).onSuccess()
+    fun `should send onSuccess event`() = mockkObject(NativeTypeFactory) {
+        every { NativeTypeFactory.writableNativeMap() } returns mockk()
+        val mockPromise = mockk<Promise>(relaxed = true)
+        RNDiscoveryListener(
+            context,
+            mockPromise,
+            mockk(relaxed = true)
+        ).onSuccess()
 
-        verify(exactly = 1) { context.sendEvent(FINISH_DISCOVERING_READERS.listenerName, any()) }
+        verify(exactly = 1) { mockPromise.resolve(any()) }
+        verify(exactly = 1) {
+            context.sendEvent(
+                FINISH_DISCOVERING_READERS.listenerName,
+                any()
+            )
+        }
 
         assertTrue(typeReplacer.sendEventSlot.captured.hasEmptyResult())
     }
 
     @Test
-    fun `should send onFailure event`() {
-        RNDiscoveryListener(context, mockk()).onFailure(EXCEPTION)
+    fun `should send onFailure event`() = mockkObject(NativeTypeFactory) {
+        every { NativeTypeFactory.writableNativeMap() } returns mockk()
+        val mockPromise = mockk<Promise>(relaxed = true)
+        RNDiscoveryListener(context, mockPromise, mockk()).onFailure(EXCEPTION)
 
+        verify(exactly = 1) { mockPromise.resolve(any()) }
         verify(exactly = 1) { context.sendEvent(FINISH_DISCOVERING_READERS.listenerName, any()) }
 
         assertTrue(typeReplacer.sendEventSlot.captured.hasError())

--- a/android/src/test/java/com/stripeterminalreactnative/listener/RNUsbReaderListenerTest.kt
+++ b/android/src/test/java/com/stripeterminalreactnative/listener/RNUsbReaderListenerTest.kt
@@ -25,7 +25,7 @@ import org.junit.ClassRule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import java.util.*
+import java.util.Date
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 


### PR DESCRIPTION
## Summary

Update Android's `discoverReaders` to properly resolve the passed in promise.

Also, fix an issue where our `discoverCancelable` could get stuck in a non-null
state, which caused any subsenquent calls to `discoverReaders` to fail with a
"busy" error.

PR is best reviewed commit-by-commit.

## Motivation

Fixes #371.

## Testing

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.

TBD updating a CHANGELOG.
