### PR TITLE
[android] RNDiscoveryListener: Delegate to NoOpCallback

### DIFF
--- a/android/src/main/java/com/stripeterminalreactnative/callback/NoOpCallback.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/callback/NoOpCallback.kt
@@ -7,7 +7,7 @@ import com.stripe.stripeterminal.external.models.TerminalException
 import com.stripeterminalreactnative.NativeTypeFactory
 import com.stripeterminalreactnative.createError
 
-internal open class NoOpCallback(private val promise: Promise) : Callback {
+internal class NoOpCallback(private val promise: Promise) : Callback {
     override fun onSuccess() {
         promise.resolve(NativeTypeFactory.writableNativeMap())
     }

--- a/android/src/main/java/com/stripeterminalreactnative/listener/RNDiscoveryListener.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/listener/RNDiscoveryListener.kt
@@ -2,6 +2,7 @@ package com.stripeterminalreactnative.listener
 
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
+import com.stripe.stripeterminal.external.callable.Callback
 import com.stripe.stripeterminal.external.callable.DiscoveryListener
 import com.stripe.stripeterminal.external.models.Reader
 import com.stripe.stripeterminal.external.models.TerminalException
@@ -17,7 +18,10 @@ internal class RNDiscoveryListener(
     promise: Promise,
     private val onDiscoveredReaders: (readers: List<Reader>) -> Unit,
     private val onComplete: () -> Unit,
-) : DiscoveryListener, NoOpCallback(promise) {
+) : DiscoveryListener, Callback {
+
+    // Our no-op callback handles resolving the promise.
+    private val noOpCallback = NoOpCallback(promise)
 
     override fun onUpdateDiscoveredReaders(readers: List<Reader>) {
         onDiscoveredReaders(readers)
@@ -27,7 +31,7 @@ internal class RNDiscoveryListener(
     }
 
     override fun onSuccess() {
-        super.onSuccess()
+        noOpCallback.onSuccess()
         context.sendEvent(ReactNativeConstants.FINISH_DISCOVERING_READERS.listenerName) {
             putMap("result", nativeMapOf())
         }
@@ -35,7 +39,7 @@ internal class RNDiscoveryListener(
     }
 
     override fun onFailure(e: TerminalException) {
-        super.onFailure(e)
+        noOpCallback.onFailure(e)
         context.sendEvent(ReactNativeConstants.FINISH_DISCOVERING_READERS.listenerName) {
             putMap("result", createError(e))
         }


### PR DESCRIPTION
## Summary

Rather than using inheritance, let's delegate to the NoOpCallback.

No functional change.

https://github.com/stripe/stripe-terminal-react-native/pull/382#discussion_r981530550
