### PR TITLE
[ios] Only resolve discoverReaders promise after callback

### DIFF
--- a/ios/StripeTerminalReactNative.swift
+++ b/ios/StripeTerminalReactNative.swift
@@ -192,14 +192,15 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, BluetoothRe
             if let error = error as NSError? {
                 let _error = Errors.createError(nsError: error)
 
+                resolve(_error)
                 self.sendEvent(withName: ReactNativeConstants.FINISH_DISCOVERING_READERS.rawValue, body: ["result": _error])
                 self.discoverCancelable = nil
             } else {
+                resolve([:])
                 self.sendEvent(withName: ReactNativeConstants.FINISH_DISCOVERING_READERS.rawValue, body: ["result": ["error": nil]])
                 self.discoverCancelable = nil
             }
         }
-        resolve([:])
     }
 
     @objc(cancelDiscovering:rejecter:)


### PR DESCRIPTION
## Summary

We want to mimic the behavior of the underlying native SDKs. This
change now matches how Android works, and it's also how the native iOS SDK
handles the completion block passed to `discoverReaders`.

Note that the underlying native SDKs behave differently for a user cancelation.
The Android SDK returns an error, and the iOS SDK returns a success.

## Motivation

Unify promise behavior at the RN layer.

Addresses:
https://github.com/stripe/stripe-terminal-react-native/issues/371#issuecomment-1260649238

## Testing

Tested with this patch:

```
diff --git a/dev-app/src/screens/DiscoverReadersScreen.tsx b/dev-app/src/screens/DiscoverReadersScreen.tsx
index 418a59b..e88a48a 100644
--- a/dev-app/src/screens/DiscoverReadersScreen.tsx
+++ b/dev-app/src/screens/DiscoverReadersScreen.tsx
@@ -140,11 +140,13 @@ export default function DiscoverReadersScreen() {
   const handleDiscoverReaders = useCallback(async () => {
     setDiscoveringLoading(true);
     // List of discovered readers will be available within useStripeTerminal hook
+    console.log('before');
     const { error: discoverReadersError } = await discoverReaders({
       discoveryMethod,
       simulated,
     });

+    console.log('after');
     if (discoverReadersError) {
       const { code, message } = discoverReadersError;
       Alert.alert('Discover readers error: ', `${code}, ${message}`);
```

1. Discover readers.
2. Cancel discovery.

Before this change, the "before" and "after" logs appeared immediately after
tapping "Discover Readers". After this change, the "after" log appeared only
after canceling discovery.
