### PR TITLE
Bump iOS to 2.13, Android to 2.14

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,7 +36,7 @@ def getExtOrIntegerDefault(name) {
     return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties['StripeTerminalReactNative_' + name]).toInteger()
 }
 
-def terminalAndroidSdkVersion = '2.12.0'
+def terminalAndroidSdkVersion = '2.14.0'
 def reactNativeSdkVersion = getVersionFromNpm()
 
 android {

--- a/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
@@ -121,6 +121,7 @@ internal fun mapFromDeviceType(type: DeviceType): String {
         DeviceType.WISEPAD_3 -> "wisePad3"
         DeviceType.WISEPOS_E -> "wisePosE"
         DeviceType.WISECUBE -> "wisecube"
+        DeviceType.STRIPE_S700 -> "stripeS700"
     }
 }
 

--- a/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
@@ -374,7 +374,7 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
 
             val configBuilder = CollectConfiguration.Builder()
             if (params.hasKey("skipTipping")) {
-                configBuilder.skipTipping = getBoolean(params, "skipTipping")
+                configBuilder.skipTipping(getBoolean(params, "skipTipping"))
             }
             val config = configBuilder.build()
 

--- a/dev-app/ios/Podfile.lock
+++ b/dev-app/ios/Podfile.lock
@@ -330,8 +330,8 @@ PODS:
     - React-RCTImage
   - stripe-terminal-react-native (0.0.1-beta.10):
     - React-Core
-    - StripeTerminal (= 2.11.0)
-  - StripeTerminal (2.11.0)
+    - StripeTerminal (= 2.13.0)
+  - StripeTerminal (2.13.0)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -505,8 +505,8 @@ SPEC CHECKSUMS:
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
   RNReanimated: 61f7efddd08550ffa5dee90021a157cd6e7c82fb
   RNScreens: 40a2cb40a02a609938137a1e0acfbf8fc9eebf19
-  stripe-terminal-react-native: d97a879bef38d9ee8533d877091103f180d6d922
-  StripeTerminal: 6644ad8f766cf7b8ea8381e922c208b7d8894468
+  stripe-terminal-react-native: 7f73ef78b99e5f4cee2a7eaa9d7898a0227001cb
+  StripeTerminal: aa6d728d8787da533f16fe04f39ef6da805dea66
   Yoga: 99652481fcd320aefa4a7ef90095b95acd181952
 
 PODFILE CHECKSUM: 584849009c1d877db9c0725b0a4a0bf94b889af9

--- a/stripe-terminal-react-native.podspec
+++ b/stripe-terminal-react-native.podspec
@@ -1,20 +1,20 @@
-require "json"
+require 'json'
 
-package = JSON.parse(File.read(File.join(__dir__, "package.json")))
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-  s.name         = "stripe-terminal-react-native"
-  s.version      = package["version"]
-  s.summary      = package["description"]
-  s.homepage     = package["homepage"]
-  s.license      = package["license"]
-  s.authors      = package["author"]
+  s.name         = 'stripe-terminal-react-native'
+  s.version      = package['version']
+  s.summary      = package['description']
+  s.homepage     = package['homepage']
+  s.license      = package['license']
+  s.authors      = package['author']
 
-  s.platforms    = { :ios => "10.0" }
-  s.source       = { :git => "https://github.com/stripe/stripe-terminal-react-native.git", :tag => "#{s.version}" }
+  s.platforms    = { ios: '10.0' }
+  s.source       = { git: 'https://github.com/stripe/stripe-terminal-react-native.git', tag: s.version.to_s }
 
-  s.source_files = "ios/**/*.{h,m,mm,swift}"
+  s.source_files = 'ios/**/*.{h,m,mm,swift}'
 
-  s.dependency "React-Core"
-  s.dependency "StripeTerminal" , "2.11.0"
+  s.dependency 'React-Core'
+  s.dependency 'StripeTerminal', '2.13.0'
 end


### PR DESCRIPTION
## Summary

Bump SDK versions in preparation for new features.

## Motivation

I'll need to use the updated SDKs for tip-eligible amounts (coming in a later PR).

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
No major changes, but tested via building dev app on iOS / Android

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
