### PR TITLE
[android] StripeTerminalReactNativeModule: Fix setting customer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @billfinn-stripe @bric-stripe @chenmin-stripe @rv-stripe
+* @billfinn-stripe @bric-stripe @chenmin-stripe @rv-stripe @chr-stripe

--- a/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
@@ -320,7 +320,7 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
             intentParams.setReceiptEmail(it)
         }
         customer?.let {
-            intentParams.setCurrency(it)
+            intentParams.setCustomer(it)
         }
         transferGroup?.let {
             intentParams.setTransferGroup(it)


### PR DESCRIPTION
## Summary

Fix typo with passing params from RN to Android.

## Motivation

Fixes #400.

## Testing

- [x] I tested this manually

``` patch
diff --git a/dev-app/src/screens/CollectCardPaymentScreen.tsx b/dev-app/src/screens/CollectCardPaymentScreen.tsx
index 7ca6c9a..0a7a3a0 100644
--- a/dev-app/src/screens/CollectCardPaymentScreen.tsx
+++ b/dev-app/src/screens/CollectCardPaymentScreen.tsx
@@ -153,6 +153,7 @@ export default function CollectCardPaymentScreen() {
       const response = await createPaymentIntent({
         amount: Number(inputValues.amount),
         currency: inputValues.currency,
+        customer: '<REDACTED>',
         paymentMethodTypes: paymentMethods,
         setupFutureUsage: enableInterac ? undefined : 'off_session',
         onBehalfOf: inputValues.connectedAccountId,
```

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
