### PR TITLE
[iOS] Fix double nesting of reader update error

### DIFF
--- a/ios/Errors.swift
+++ b/ios/Errors.swift
@@ -17,20 +17,20 @@ class Errors {
         return joined.isEmpty ? nil : joined
     }
 
-    class func createError(code: ErrorCode.Code, message: String) -> NSDictionary {
+    class func createError(code: ErrorCode.Code, message: String) -> [String: Any] {
         return createError(errorCode: code.stringValue, message: message)
     }
 
-    class func createError(code: CommonErrorType, message: String) -> NSDictionary {
+    class func createError(code: CommonErrorType, message: String) -> [String: Any] {
         return createError(errorCode: code.rawValue, message: message)
     }
 
-    class func createError(nsError: NSError) -> NSDictionary {
+    class func createError(nsError: NSError) -> [String: Any?] {
         return createError(code: ErrorCode.Code.init(rawValue: nsError.code) ?? ErrorCode.unexpectedSdkError, message: nsError.localizedDescription)
     }
 
-    private class func createError(errorCode: String, message: String) -> NSDictionary {
-        let error: NSDictionary = [
+    private class func createError(errorCode: String, message: String) -> [String: Any] {
+        let error = [
             "code": errorCode,
             "message": message
         ]

--- a/ios/StripeTerminalReactNative.swift
+++ b/ios/StripeTerminalReactNative.swift
@@ -713,7 +713,12 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, BluetoothRe
     func reader(_ reader: Reader, didFinishInstallingUpdate update: ReaderSoftwareUpdate?, error: Error?) {
         var result = Mappers.mapFromReaderSoftwareUpdate(update) ?? [:]
         if let nsError = error as NSError? {
-            result["error"] = Errors.createError(nsError: nsError)
+           let errorAsDictionary = Errors.createError(nsError: nsError)
+            // createError will return a dictionary of ["error": {the error}]
+            // so merge that with the result so we have a single result.error
+            result = result.merging(errorAsDictionary, uniquingKeysWith: { _, error in
+                error
+            })
         }
         sendEvent(withName: ReactNativeConstants.FINISH_INSTALLING_UPDATE.rawValue, body: ["result": result])
     }


### PR DESCRIPTION
## Summary
Fixes https://github.com/stripe/stripe-terminal-react-native/issues/384

`createError` returns a dictionary with the "error" key already. So when an update failed we were unintentionally nesting that again and so we got error.error.[message|code].

<!-- Simple summary of what was changed. -->

## Motivation
https://github.com/stripe/stripe-terminal-react-native/issues/384
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

## Testing

Tested by setting the update to fail for the simulated reader and confirmed the error isn't double nested:

| before | after |
| --- | --- |
|  `LOG  [Stripe terminal]: didFinishInstallingUpdate {"deviceSoftwareVersion": "2.01.00.08-SZZZ_US_v9-300001", "error": {"error": {"code": "ReaderSoftwareUpdateFailedBatteryLow", "message": "Updating the reader software failed because the reader's battery is too low. Charge the reader before trying again."}}, "estimatedUpdateTime": "estimate1To2Minutes", "requiredAt": "1667398040759"}` | `LOG  [Stripe terminal]: didFinishInstallingUpdate {"deviceSoftwareVersion": "2.01.00.08-SZZZ_US_v9-300001", "error": {"code": "ReaderSoftwareUpdateFailedBatteryLow", "message": "Updating the reader software failed because the reader's battery is too low. Charge the reader before trying again."}, "estimatedUpdateTime": "estimate1To2Minutes", "requiredAt": "1667400527113"}` |

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually

## Documentation

Select one:

- [x] This PR does not result in any developer-facing changes.
