### PR TITLE
Bump iOS versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Updating to a newer version of the SDK? See our [release notes](https://github.c
 
 ### iOS
 
-- Compatible with apps targeting iOS 10 or above.
+- Compatible with apps targeting iOS 11 or above.
 
 ## Try the example app
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -134,7 +134,7 @@ workflows:
     - complete_all
     meta:
       bitrise.io:
-        stack: osx-xcode-13.3.x
+        stack: osx-xcode-14.0.x-ventura
         machine_type_id: g2.12core
   example-build-ios:
     steps:
@@ -245,7 +245,7 @@ workflows:
     - complete_all
 meta:
   bitrise.io:
-    stack: osx-xcode-13.3.x
+    stack: osx-xcode-14.0.x-ventura
     machine_type_id: g2-m1.8core
 app:
   envs:

--- a/dev-app/ios/Podfile.lock
+++ b/dev-app/ios/Podfile.lock
@@ -505,7 +505,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
   RNReanimated: 61f7efddd08550ffa5dee90021a157cd6e7c82fb
   RNScreens: 40a2cb40a02a609938137a1e0acfbf8fc9eebf19
-  stripe-terminal-react-native: 128db7d66efde785a2da91e36ad550c65172209a
+  stripe-terminal-react-native: 9e498e2c51bcbd38f62a1d95c9127611f3039ed7
   StripeTerminal: 11f19c848985f980a708b4993ff59448637f5c82
   Yoga: 99652481fcd320aefa4a7ef90095b95acd181952
 

--- a/stripe-terminal-react-native.podspec
+++ b/stripe-terminal-react-native.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license      = package['license']
   s.authors      = package['author']
 
-  s.platforms    = { ios: '10.0' }
+  s.platforms    = { ios: '11.0' }
   s.source       = { git: 'https://github.com/stripe/stripe-terminal-react-native.git', tag: s.version.to_s }
 
   s.source_files = 'ios/**/*.{h,m,mm,swift}'


### PR DESCRIPTION
## Summary

- Bump XCode version used by bitrise to match the version we use internally
  when building the iOS SDK.
- Update the podspec iOS version to 11, which is required as of iOS native SDK
  version 2.14.0.

## Motivation

Fix CI and update iOS version.

## Testing

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [x] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
