### PR TITLE
Add missing mapper for iOS ChargeStatus enum

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -96,7 +96,7 @@ workflows:
             set -e
             # This is a terrible hack, as I haven't worked out how Bitrise's `pod install` step interacts with the rbenv set in this app. You definitely shouldn't copy this.
             cd dev-app/ios && rbenv install 2.7.4 && bundle install && \
-            gem install cocoapods && pod install && cd - && \
+            gem install cocoapods -v 1.11.3 && pod install && cd - && \
             echo "Checking for diffs in pod lockfile, if this fails please ensure all dependencies are up to date" && \
             git diff --exit-code
         title: Set up cocoapods

--- a/ios/Mappers.swift
+++ b/ios/Mappers.swift
@@ -209,6 +209,15 @@ class Mappers {
         }
     }
 
+    class func mapFromChargeStatus(_ status: ChargeStatus) -> String {
+        switch status {
+        case ChargeStatus.failed: return "failed"
+        case ChargeStatus.pending: return "pending"
+        case ChargeStatus.succeeded: return "succeeded"
+        default: return "unknown"
+        }
+    }
+
     class func mapFromReaderDisplayMessage(_ displayMessage: ReaderDisplayMessage) -> String {
         switch displayMessage {
         case ReaderDisplayMessage.insertCard: return "insertCard"
@@ -321,7 +330,7 @@ class Mappers {
             "amount": charge.amount,
             "description": charge.stripeDescription ?? NSNull(),
             "currency": charge.currency,
-            "status": charge.status,
+            "status": mapFromChargeStatus(charge.status),
             "id": charge.stripeId,
         ]
         return result


### PR DESCRIPTION
## Summary
Fixes https://github.com/stripe/stripe-terminal-react-native/issues/440

The iOS layer was missing a mapper from the ChargeStatus enum to a string. This adds that.

<!-- Simple summary of what was changed. -->

## Motivation
#440 

<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

stepped through the mapper after a payment and also added a print out on the js side to see charges[0].status was set now.

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
