### PR TITLE
bitrise: Set apple dev connection to "off"

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -41,6 +41,7 @@ workflows:
     steps:
     - fastlane@3:
         inputs:
+        - connection: "off"
         - lane: increment_version app_id:$FIREBASE_APP_ID_ANDROID version_suffix:$VERSION_SUFFIX
         title: fastlane increment version
     - yarn@0:
@@ -50,6 +51,7 @@ workflows:
         title: Build app for Firebase deploy
     - fastlane@3:
         inputs:
+        - connection: "off"
         - lane: publish_to_firebase app_id:$FIREBASE_APP_ID_ANDROID firebase_token:$FIREBASE_TOKEN
         title: fastlane distribute app
     before_run:


### PR DESCRIPTION
## Summary

Attempt to fix build errors like:

> Could not configure Apple Service authentication: 2FA session saved
> in Bitrise Developer Connection is expired, was valid until 2023-03-12
> 21:32:16 +0000 UTC (exit code: 1)

https://app.bitrise.io/build/0565de0f-1eef-4d6c-a660-b6c5c709b6f4