### PR TITLE
Add deviceType of reader for TTPOI.

### DIFF
--- a/ios/Mappers.swift
+++ b/ios/Mappers.swift
@@ -71,6 +71,7 @@ class Mappers {
         case DeviceType.wisePosE: return "wisePosE"
         case DeviceType.wisePosEDevKit: return "wisePosEDevkit"
         case DeviceType.stripeS700DevKit: return "stripeS700Devkit"
+        case DeviceType.appleBuiltIn: return "appleBuiltIn"
         default: return "unknown"
         }
     }

--- a/src/types/Reader.ts
+++ b/src/types/Reader.ts
@@ -90,7 +90,8 @@ export namespace Reader {
     | 'wisePad3s'
     | 'wisePadEDevkit'
     | 'stripeS700Devkit'
-    | 'cotsDevice';
+    | 'cotsDevice'
+    | 'appleBuiltIn';
 
   export type InputOptions = 'insertCard' | 'swipeCard' | 'tapCard';
 


### PR DESCRIPTION
## Summary

Add deviceType of reader for TTPOI.

## Motivation

When I wanted to use it to tell if my current connection was a TTPOI reader and skip connect, I found that there was no such deviceType. Just like the code below, so I want to add it.
```ts
if (connectedReader?.deviceType == 'appleBuiltIn') {
  // do something
}
```

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
