### PR TITLE
Add error handle when call initialize api.

### DIFF
--- a/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
@@ -93,7 +93,7 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
 
     @ReactMethod
     @Suppress("unused")
-    fun initialize(params: ReadableMap, promise: Promise) {
+    fun initialize(params: ReadableMap, promise: Promise) = withExceptionResolver(promise) {
         UiThreadUtil.runOnUiThread { onCreate(context.applicationContext as Application) }
 
         val result = if (!Terminal.isInitialized()) {


### PR DESCRIPTION
## Summary

Add error handle when calling initialize API on Android.

## Motivation

When I call this interface when the Bluetooth permission is not granted, it will crash my APP.

## Testing

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
