### PR TITLE
fix: Provide correct resource name for collectSetupIntentPaymentMetho…

### DIFF
--- a/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
@@ -474,7 +474,7 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
             val customerConsentCollected = getBoolean(params, "customerConsentCollected")
 
             val setupIntent = requireParam(setupIntents[setupIntentId]) {
-                "There is no created paymentIntent with id $setupIntentId"
+                "There is no created setupIntent with id $setupIntentId"
             }
             collectSetupIntentCancelable = terminal.collectSetupIntentPaymentMethod(
                 setupIntent,


### PR DESCRIPTION
## Summary

Changed the resource name referenced in the message for `collectSetupIntentPaymentMethod` when `setupIntentId` is not present via `requireParam` in the Android Kotlin module

## Motivation

Encountered this issue during upstream consumption of the package in an internal work application. This should avoid any chance of confusion for the future!

## Testing

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
