### PR TITLE
Add withExceptionResolver to Android Terminal init function

### DIFF
--- a/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
@@ -93,7 +93,7 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
 
     @ReactMethod
     @Suppress("unused")
-    fun initialize(params: ReadableMap, promise: Promise) {
+    fun initialize(params: ReadableMap, promise: Promise) = withExceptionResolver(promise) {
         UiThreadUtil.runOnUiThread { onCreate(context.applicationContext as Application) }
 
         val result = if (!Terminal.isInitialized()) {

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -97,7 +97,7 @@ workflows:
             - content: |-
                 set -e
                 # This is a terrible hack, as I haven't worked out how Bitrise's `pod install` step interacts with the rbenv set in this app. You definitely shouldn't copy this.
-                cd dev-app/ios && rbenv install 2.7.4 && bundle install && \
+                cd dev-app/ios && asdf install ruby 2.7.4 && bundle install && \
                 gem install cocoapods -v 1.12.1 && pod install && cd - && \
                 echo "Checking for diffs in pod lockfile, if this fails please ensure all dependencies are up to date" && \
                 git diff --exit-code

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -136,8 +136,8 @@ workflows:
       - complete_all
     meta:
       bitrise.io:
-        stack: osx-xcode-14.0.x-ventura
-        machine_type_id: g2.12core
+        stack: linux-docker-android-20.04
+        machine_type_id: elite-xl
   example-build-ios:
     steps:
       - cocoapods-install@2:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -176,6 +176,7 @@ workflows:
       - script@1:
           inputs:
             - content: |-
+                asdf install nodejs 16.15.0
                 echo 'export PATH="$PATH:~/project/node_modules/.bin:~/project/dev-app/node_modules/.bin"' >> $BASH_ENV
                 source $BASH_ENV
                 brew update >/dev/null


### PR DESCRIPTION
## Summary

<!-- Simple summary of what was changed. -->
Due to Bitrise updates our builds have been failing and preventing us from merging PRs. This PR fixes the Bitrise build errors and also includes a user submitted bug fix [0] for Android initialization error.

[0] https://github.com/stripe/stripe-terminal-react-native/pull/463

## Motivation

<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->
https://github.com/stripe/stripe-terminal-react-native/issues/484
Bitrise failures

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
