### PR TITLE
Support  refundApplicationFee and reverseTransfer options in in-person refunds

### DIFF
--- a/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
@@ -569,8 +569,14 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
             val currency = requireParam(params.getString("currency")) {
                 "You must provide a currency value"
             }
+            val refundApplicationFee = params.getBoolean("refundApplicationFee")
+            val reverseTransfer = params.getBoolean("reverseTransfer")
 
-            val intentParams = RefundParameters.Builder(chargeId, amount, currency).build()
+            val intentParamsBuild = RefundParameters.Builder(chargeId, amount, currency)
+            intentParamsBuild.setRefundApplicationFee(refundApplicationFee)
+                .setReverseTransfer(reverseTransfer)
+            val intentParams = intentParamsBuild.build()
+
             collectRefundPaymentMethodCancelable = terminal.collectRefundPaymentMethod(
                 intentParams, NoOpCallback(promise)
             )

--- a/dev-app/src/screens/RefundPaymentScreen.tsx
+++ b/dev-app/src/screens/RefundPaymentScreen.tsx
@@ -1,6 +1,6 @@
 import { useNavigation, useRoute, RouteProp } from '@react-navigation/core';
 import React, { useContext, useState } from 'react';
-import { Platform, StyleSheet, Text, TextInput } from 'react-native';
+import { Platform, StyleSheet, Switch, Text, TextInput } from 'react-native';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 import { useStripeTerminal } from '@stripe/stripe-terminal-react-native';
 import { colors } from '../colors';
@@ -16,10 +16,14 @@ export default function RefundPaymentScreen() {
     chargeId: string;
     amount: string;
     currency: string;
+    refundApplicationFee?: boolean;
+    reverseTransfer?: boolean;
   }>({
     chargeId: lastSuccessfulChargeId || '',
     amount: '100',
     currency: 'CAD',
+    refundApplicationFee: false,
+    reverseTransfer: false,
   });
   const navigation = useNavigation();
   const { params } = useRoute<RouteProp<RouteParamList, 'RefundPayment'>>();
@@ -220,6 +224,42 @@ export default function RefundPaymentScreen() {
             setInputValues((state) => ({ ...state, currency: value }))
           }
           placeholder="currency"
+        />
+      </List>
+
+      <List bolded={false} topSpacing={false} title="REFUND APPLICATION FEE">
+        <ListItem
+          title="Refund Application Fee"
+          rightElement={
+            <Switch
+              testID="refund-application-fee"
+              value={inputValues.refundApplicationFee}
+              onValueChange={(value) => {
+                setInputValues((state) => ({
+                  ...state,
+                  refundApplicationFee: value,
+                }));
+              }}
+            />
+          }
+        />
+      </List>
+
+      <List bolded={false} topSpacing={false} title="REVERSE TRANSFER">
+        <ListItem
+          title="Reverse Transfer"
+          rightElement={
+            <Switch
+              testID="reverse-transfer"
+              value={inputValues.reverseTransfer}
+              onValueChange={(value) =>
+                setInputValues((state) => ({
+                  ...state,
+                  reverseTransfer: value,
+                }))
+              }
+            />
+          }
         />
       </List>
 

--- a/ios/StripeTerminalReactNative.swift
+++ b/ios/StripeTerminalReactNative.swift
@@ -682,8 +682,12 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, BluetoothRe
         let amount = params["amount"] as? NSNumber
         let currency = params["currency"] as? String
         let intAmount = UInt(truncating: amount!);
+        let refundApplicationFee = params["refundApplicationFee"] as? NSNumber
+        let reverseTransfer = params["reverseTransfer"] as? NSNumber
 
         let refundParams = RefundParameters(chargeId: chargeId!, amount: intAmount, currency: currency!)
+        refundParams.refundApplicationFee = refundApplicationFee
+        refundParams.reverseTransfer = reverseTransfer
 
         self.collectRefundPaymentMethodCancelable = Terminal.shared.collectRefundPaymentMethod(refundParams) { error in
             if let error = error as NSError? {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -232,6 +232,8 @@ export type RefundParams = {
   chargeId: string;
   amount: number;
   currency: string;
+  refundApplicationFee?: boolean;
+  reverseTransfer?: boolean;
 };
 
 export type CardPresent = {


### PR DESCRIPTION

## Summary

Support refundApplicationFee and reverseTransfer options in in-person refunds.

## Motivation

For in-person refunds the dev app is missing the refundApplicationFee and reverseTransfer options.

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
