### PR TITLE
Example env file for fastlane auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ test-butler-app.apk
 # Fastlane
 /fastlane/README.md
 /fastlane/report.xml
+/fastlane/.env.default

--- a/fastlane/.env.default.example
+++ b/fastlane/.env.default.example
@@ -1,0 +1,3 @@
+# replace these values with your Apple account ID and App-Specific Password
+FASTLANE_USER=<Apple USER ID>
+FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD=<App-Specific Password>


### PR DESCRIPTION
## Summary

<!-- Simple summary of what was changed. -->
For Apple dev account authentication for Fastlane deployers should set Apple ID and app-specific password in the env.default file. Adds an example and ignores the actual file

## Motivation

<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->
RN deploy improvements

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
