### PR TITLE
Cache token provider callback between re-renders.

### DIFF
--- a/dev-app/src/Root.tsx
+++ b/dev-app/src/Root.tsx
@@ -61,7 +61,7 @@ export default function Root() {
     initAccount();
   }, [onSelectAccount]);
 
-  const fetchTokenProvider = async (): Promise<string> => {
+  const fetchTokenProvider = useCallback(async (): Promise<string> => {
     if (!api) {
       return '';
     }
@@ -72,7 +72,7 @@ export default function Root() {
     }
 
     return resp?.secret || '';
-  };
+  }, []);
 
   return (
     <AppContext.Provider

--- a/example-app/src/Root.tsx
+++ b/example-app/src/Root.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 
 import { StripeTerminalProvider } from '@stripe/stripe-terminal-react-native';
 import App from './App';
@@ -9,9 +9,8 @@ export default function Root() {
     string | null
   >(null);
 
-  const fetchTokenProvider = async (): Promise<string> => {
+  const fetchTokenProvider = useCallback(async (): Promise<string> => {
     if (!api) {
-      console.log('hi hi hi');
       return '';
     }
 
@@ -23,7 +22,7 @@ export default function Root() {
     }
 
     return resp?.secret || '';
-  };
+  }, []);
 
   return (
     <AppContext.Provider


### PR DESCRIPTION
## Summary

Prevent instantiating a new fetchTokenProvider function on each render pass.

## Motivation

Prevents the dev/example apps from reinitializing the Terminal SDK
more than once when unnecessary.

## Testing

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
