### PR TITLE
Fix discovery-readers cannot scroll down registered devices list.

### DIFF
--- a/dev-app/src/screens/DiscoverReadersScreen.tsx
+++ b/dev-app/src/screens/DiscoverReadersScreen.tsx
@@ -424,7 +424,7 @@ export default function DiscoverReadersScreen() {
 const styles = StyleSheet.create({
   container: {
     backgroundColor: colors.light_gray,
-    height: '100%',
+    alignSelf: 'stretch',
   },
   pickerContainer: {
     position: 'absolute',


### PR DESCRIPTION
## Summary
- Modify style of  Scrollview to make it adapt its height based on the size of its sub-container to display the content correctly.

## Motivation
- Users cannot scroll down the readers list in the  app in order to find and connect to an already registered reader if the list is larger than the screen displayed.

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
