### PR TITLE
Fix not specifying autoReconnectOnUnexpectedDisconnect issue.

### DIFF
--- a/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
@@ -85,7 +85,8 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
 
                 override fun onLowMemory() {}
                 override fun onConfigurationChanged(p0: Configuration) {}
-            })
+            }
+        )
     }
 
     override fun getConstants(): MutableMap<String, Any> =
@@ -159,7 +160,7 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
     fun setConnectionToken(params: ReadableMap, promise: Promise) {
         tokenProvider.setConnectionToken(
             token = params.getString("token"),
-            error = params.getString("error"),
+            error = params.getString("error")
         )
         promise.resolve(null)
     }
@@ -214,9 +215,11 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
 
                 val serialNumber = reader.getString("serialNumber")
 
-                val selectedReader = requireParam(discoveredReadersList.find {
-                    it.serialNumber == serialNumber
-                }) {
+                val selectedReader = requireParam(
+                    discoveredReadersList.find {
+                        it.serialNumber == serialNumber
+                    }
+                ) {
                     "Could not find a reader with serialNumber $serialNumber"
                 }
 
@@ -224,8 +227,14 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
                     params.getString("locationId") ?: selectedReader.location?.id.orEmpty()
 
                 val autoReconnectOnUnexpectedDisconnect = if (discoveryMethod == DiscoveryMethod.BLUETOOTH_SCAN || discoveryMethod == DiscoveryMethod.USB) {
-                    params.getBoolean("autoReconnectOnUnexpectedDisconnect") ?: false
-                } else false
+                    if (params.hasKey("autoReconnectOnUnexpectedDisconnect")) {
+                        params.getBoolean("autoReconnectOnUnexpectedDisconnect")
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                }
 
                 val reconnectionListener = RNReaderReconnectionListener(context) {
                     cancelReaderConnectionCancellable = it
@@ -322,8 +331,11 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
         val captureMethod = params.getString("captureMethod")
 
         val paymentMethodTypes = paymentMethods?.toArrayList()?.mapNotNull {
-            if (it is String) PaymentMethodType.valueOf(it.uppercase())
-            else null
+            if (it is String) {
+                PaymentMethodType.valueOf(it.uppercase())
+            } else {
+                null
+            }
         }
 
         val intentParams = paymentMethodTypes?.let {
@@ -394,9 +406,12 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
             }
         }
 
-        terminal.createPaymentIntent(intentParams.build(), RNPaymentIntentCallback(promise) {
-            paymentIntents[it.id] = it
-        })
+        terminal.createPaymentIntent(
+            intentParams.build(),
+            RNPaymentIntentCallback(promise) {
+                paymentIntents[it.id] = it
+            }
+        )
     }
 
     @ReactMethod
@@ -437,9 +452,12 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
     @ReactMethod
     @Suppress("unused")
     fun retrievePaymentIntent(clientSecret: String, promise: Promise) {
-        terminal.retrievePaymentIntent(clientSecret, RNPaymentIntentCallback(promise) {
-            paymentIntents[it.id] = it
-        })
+        terminal.retrievePaymentIntent(
+            clientSecret,
+            RNPaymentIntentCallback(promise) {
+                paymentIntents[it.id] = it
+            }
+        )
     }
 
     @ReactMethod
@@ -449,9 +467,12 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
             "There is no associated paymentIntent with id $paymentIntentId"
         }
 
-        terminal.processPayment(paymentIntent, RNPaymentIntentCallback(promise) {
-            paymentIntents.clear()
-        })
+        terminal.processPayment(
+            paymentIntent,
+            RNPaymentIntentCallback(promise) {
+                paymentIntents.clear()
+            }
+        )
     }
 
     @ReactMethod
@@ -472,17 +493,23 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
             SetupIntentParameters.Builder().setCustomer(customerId).build()
         } ?: SetupIntentParameters.NULL
 
-        terminal.createSetupIntent(intentParams, RNSetupIntentCallback(promise) {
-            setupIntents[it.id] = it
-        })
+        terminal.createSetupIntent(
+            intentParams,
+            RNSetupIntentCallback(promise) {
+                setupIntents[it.id] = it
+            }
+        )
     }
 
     @ReactMethod
     @Suppress("unused")
     fun retrieveSetupIntent(clientSecret: String, promise: Promise) {
-        terminal.retrieveSetupIntent(clientSecret, RNSetupIntentCallback(promise) {
-            setupIntents[it.id] = it
-        })
+        terminal.retrieveSetupIntent(
+            clientSecret,
+            RNSetupIntentCallback(promise) {
+                setupIntents[it.id] = it
+            }
+        )
     }
 
     @ReactMethod
@@ -492,9 +519,12 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
             val paymentIntent = requireParam(paymentIntents[paymentIntentId]) {
                 "There is no associated paymentIntent with id $paymentIntentId"
             }
-            terminal.cancelPaymentIntent(paymentIntent, RNPaymentIntentCallback(promise) {
-                paymentIntents[it.id] = null
-            })
+            terminal.cancelPaymentIntent(
+                paymentIntent,
+                RNPaymentIntentCallback(promise) {
+                    paymentIntents[it.id] = null
+                }
+            )
         }
 
     @ReactMethod
@@ -547,7 +577,9 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
         }
 
         val cartLineItems =
-            mapToCartLineItems(params.getArray("lineItems") ?: NativeTypeFactory.writableNativeArray())
+            mapToCartLineItems(
+                params.getArray("lineItems") ?: NativeTypeFactory.writableNativeArray()
+            )
 
         val cart = Cart.Builder(
             currency = currency,
@@ -569,9 +601,13 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
 
             val params = SetupIntentCancellationParameters.Builder().build()
 
-            terminal.cancelSetupIntent(setupIntent, params, RNSetupIntentCallback(promise) {
-                setupIntents[setupIntent.id] = null
-            })
+            terminal.cancelSetupIntent(
+                setupIntent,
+                params,
+                RNSetupIntentCallback(promise) {
+                    setupIntents[setupIntent.id] = null
+                }
+            )
         }
 
     @ReactMethod
@@ -582,9 +618,12 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
                 "There is no associated setupIntent with id $setupIntentId"
             }
 
-            terminal.confirmSetupIntent(setupIntent, RNSetupIntentCallback(promise) {
-                setupIntents[it.id] = null
-            })
+            terminal.confirmSetupIntent(
+                setupIntent,
+                RNSetupIntentCallback(promise) {
+                    setupIntents[it.id] = null
+                }
+            )
         }
 
     @ReactMethod
@@ -615,7 +654,8 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
             val intentParams = intentParamsBuild.build()
 
             collectRefundPaymentMethodCancelable = terminal.collectRefundPaymentMethod(
-                intentParams, NoOpCallback(promise)
+                intentParams,
+                NoOpCallback(promise)
             )
         }
 
@@ -658,6 +698,6 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
     }
 
     private fun busyMessage(command: String, busyBy: String): String {
-        return  "Could not execute $command because the SDK is busy with another command: $busyBy."
+        return "Could not execute $command because the SDK is busy with another command: $busyBy."
     }
 }


### PR DESCRIPTION
## Summary

Fixe #532 

Fix issue that Calling connectBlueToothReader without autoReconnectOnUnexpectedDisconnect will case execption.

## Motivation

Fix #532 

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
