### PR TITLE
feat: allow customization of Local Network message for Expo projects on iOS

### DIFF
--- a/example-app/app.json
+++ b/example-app/app.json
@@ -17,7 +17,8 @@
           "bluetoothBackgroundMode": true,
           "locationWhenInUsePermission": "Location access is required in order to accept payments.",
           "bluetoothPeripheralPermission": "Bluetooth access is required in order to connect to supported bluetooth card readers.",
-          "bluetoothAlwaysUsagePermission": "This app uses Bluetooth to connect to supported card readers."
+          "bluetoothAlwaysUsagePermission": "This app uses Bluetooth to connect to supported card readers.",
+          "localNetworkUsagePermission": "This app uses the local WiFi network to connect to supported card readers."
         }
       ]
     ],

--- a/src/plugin/withStripeTerminal.ts
+++ b/src/plugin/withStripeTerminal.ts
@@ -26,6 +26,7 @@ type StripeTerminalPluginProps = {
   locationWhenInUsePermission?: string;
   bluetoothPeripheralPermission?: string;
   bluetoothAlwaysUsagePermission?: string;
+  localNetworkUsagePermission?: string;
 };
 
 const withStripeTerminal: ConfigPlugin<StripeTerminalPluginProps> = (
@@ -139,6 +140,10 @@ const withStripeTerminalIos: ConfigPlugin<StripeTerminalPluginProps> = (
     config.modResults.NSBluetoothAlwaysUsageDescription =
       props.bluetoothAlwaysUsagePermission ||
       'This app uses Bluetooth to connect to supported card readers.';
+
+    config.modResults.NSLocalNetworkUsageDescription =
+      props.localNetworkUsagePermission ||
+      'This app uses the local WiFi network to connect to supported card readers.';
     return config;
   });
 };


### PR DESCRIPTION
## Summary

Allow customisation of the pop-up message that appears when an Expo-based app attempts to connect to an Internet card reader for the first time, on iOS.

## Motivation

On iOS 14+, the first time that the app attempts to connect to an Internet card reader (such as the WisePOS), a message appears asking the user to allow access to the Local Network. The description that appears can be customised by setting the [`NSLocalNetworkUsageDescription` property list key](https://developer.apple.com/documentation/bundleresources/information_property_list/nslocalnetworkusagedescription). This change allows the description to be customised in an Expo app by setting the `localNetworkUsagePermission` property in the relevant plugin config.

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.

If/when this is merged and released, this will require changes to the [setup integration docs](https://stripe.com/docs/terminal/payments/setup-integration?terminal-sdk-platform=react-native).