### PR TITLE
Added correct example app name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,5 +196,3 @@ Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcem
 
 For answers to common questions about this code of conduct, see the FAQ at
 https://www.contributor-covenant.org/faq. Translations are available at https://www.contributor-covenant.org/translations.
-
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,27 +9,29 @@ To get started with the project, run `yarn` in the root directory to install the
 ```sh
 yarn
 ```
-
 > While it's possible to use [`npm`](https://github.com/npm/cli), the tooling is built around [`yarn`](https://classic.yarnpkg.com/), so you'll have an easier time if you use `yarn` for development.
 
-While developing, you can run the [example app](/example/) to test your changes. Any changes you make in your library's JavaScript code will be reflected in the example app without a rebuild. If you change any native code, then you'll need to rebuild the example app.
+If the installation fails with `xcrun: error: SDK "iphoneos"`, make sure [Xcode](https://apps.apple.com/us/app/xcode/id497799835?mt=12/) is installed, and the [Xcode command line tools are set correclty](https://stackoverflow.com/questions/68565356/xcrun-error-sdk-iphoneos-cannot-be-located).
+
+
+While developing, you can run the [example app](/example-app/) to test your changes. Any changes you make in your library's JavaScript code will be reflected in the example app without a rebuild. If you change any native code, then you'll need to rebuild the example app.
 
 To start the packager:
 
 ```sh
-yarn example start
+yarn example-app start
 ```
 
 To run the example app on Android:
 
 ```sh
-yarn example android
+yarn example-app android
 ```
 
 To run the example app on iOS:
 
 ```sh
-yarn example ios
+yarn example-app ios
 ```
 
 Make sure your code passes TypeScript and ESLint. Run the following to verify:
@@ -194,3 +196,5 @@ Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcem
 
 For answers to common questions about this code of conduct, see the FAQ at
 https://www.contributor-covenant.org/faq. Translations are available at https://www.contributor-covenant.org/translations.
+
+


### PR DESCRIPTION
## Summary

`CONTRIBUTING.md` had multiple references to this repo's example project. In `CONTRIBUTING.md`, the example project was supposed to belong in the `/example` directory, when it was actually in the `/example-app` directory. The `/example` directory does not exist. 

## Motivation

This is a tiny correction, but it adds a bit of unnecessary friction to the onboarding process :) 

## Testing

N/A - all changes were made to docs. None of the functionality was changed. 

- [ ] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [x] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
