### PR TITLE
Laulhus/fix create setup intent params

### DIFF
--- a/dev-app/src/screens/SetupIntentScreen.tsx
+++ b/dev-app/src/screens/SetupIntentScreen.tsx
@@ -228,7 +228,7 @@ export default function SetupIntentScreen() {
       }
 
       const response = await createSetupIntent({
-        customerId: resp.id,
+        customer: resp.id,
       });
       setupIntent = response.setupIntent;
       setupIntentError = response.error;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -195,7 +195,7 @@ export type CollectSetupIntentPaymentMethodParams = {
 };
 
 export type CreateSetupIntentParams = {
-  customerId?: string;
+  customer?: string;
 };
 
 export type PaymentIntentResultType =


### PR DESCRIPTION
## Summary

Changed property name _customerId_ to _customer_ in CreateSetupIntentParams

## Motivation

Fixing mismatch between types file and published documentation. 
Issue: https://github.com/stripe/stripe-terminal-react-native/issues/591#issue-2039484717

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [X] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [X] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
