### PR TITLE
Fix metadata missing issue

### DIFF
--- a/dev-app/src/api/api.ts
+++ b/dev-app/src/api/api.ts
@@ -127,6 +127,7 @@ export class Api {
     capture_method,
     on_behalf_of,
     application_fee_amount,
+    metadata,
   }: NewPaymentIntentCreateParams): Promise<
     Stripe.PaymentIntent | { error: Stripe.StripeRawError }
   > {
@@ -179,6 +180,15 @@ export class Api {
 
     if (application_fee_amount) {
       formData.append('application_fee_amount', String(application_fee_amount));
+    }
+
+    if (metadata) {
+      Object.keys(metadata).forEach((k) => {
+        formData.append(
+          `metadata[${k.toString()}]`,
+          JSON.stringify(metadata[k]).replaceAll('"', '')
+        );
+      });
     }
 
     formData.append('payment_method_types[]', 'card_present');


### PR DESCRIPTION
## Summary

Add metadata for createPaymentIntent in internet mode.

## Motivation

To support 'metadata' field in internet mode.

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
