### PR TITLE
sPOS offline mode support

### DIFF
--- a/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
@@ -6,8 +6,9 @@ import com.facebook.react.bridge.WritableArray
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.WritableNativeArray
 import com.stripe.stripeterminal.external.CollectInputs
-import com.stripe.stripeterminal.external.models.AmountDetails
+import com.stripe.stripeterminal.external.OfflineMode
 import com.stripe.stripeterminal.external.models.Address
+import com.stripe.stripeterminal.external.models.AmountDetails
 import com.stripe.stripeterminal.external.models.CardDetails
 import com.stripe.stripeterminal.external.models.CardPresentDetails
 import com.stripe.stripeterminal.external.models.CartLineItem
@@ -21,6 +22,8 @@ import com.stripe.stripeterminal.external.models.Location
 import com.stripe.stripeterminal.external.models.LocationStatus
 import com.stripe.stripeterminal.external.models.NetworkStatus
 import com.stripe.stripeterminal.external.models.NumericResult
+import com.stripe.stripeterminal.external.models.OfflineCardPresentDetails
+import com.stripe.stripeterminal.external.models.OfflineDetails
 import com.stripe.stripeterminal.external.models.OfflineStatus
 import com.stripe.stripeterminal.external.models.PaymentIntent
 import com.stripe.stripeterminal.external.models.PaymentIntentStatus
@@ -34,9 +37,6 @@ import com.stripe.stripeterminal.external.models.ReaderAccessibility
 import com.stripe.stripeterminal.external.models.ReaderDisplayMessage
 import com.stripe.stripeterminal.external.models.ReaderEvent
 import com.stripe.stripeterminal.external.models.ReaderInputOptions
-import com.stripe.stripeterminal.external.models.OfflineCardPresentDetails
-import com.stripe.stripeterminal.external.models.OfflineDetails
-import com.stripe.stripeterminal.external.OfflineMode
 import com.stripe.stripeterminal.external.models.ReaderInputOptions.ReaderInputOption
 import com.stripe.stripeterminal.external.models.ReaderSettings
 import com.stripe.stripeterminal.external.models.ReaderSoftwareUpdate
@@ -528,7 +528,10 @@ private fun mapFromOfflineDetails(offlineDetails: OfflineDetails?): ReadableMap?
         nativeMapOf {
             putString("storedAt", offlineDetails.storedAt.toString())
             putBoolean("requiresUpload", offlineDetails.requiresUpload)
-            putMap("cardPresentDetails", mapFromOfflineCardPresentDetails(offlineDetails.cardPresentDetails))
+            putMap(
+                "cardPresentDetails",
+                mapFromOfflineCardPresentDetails(offlineDetails.cardPresentDetails)
+            )
             putMap("amountDetails", mapFromAmountDetails(offlineDetails.amountDetails))
         }
     }
@@ -536,10 +539,9 @@ private fun mapFromOfflineDetails(offlineDetails: OfflineDetails?): ReadableMap?
 private fun mapFromAmountDetails(amountDetails: AmountDetails?): ReadableMap? =
     amountDetails?.let {
         nativeMapOf {
-            putMap("tip", nativeMapOf{ putInt("amount", amountDetails.tip?.amount?.toInt() ?: 0) })
+            putMap("tip", nativeMapOf { putInt("amount", amountDetails.tip?.amount?.toInt() ?: 0) })
         }
     }
-
 
 private fun mapFromOfflineCardPresentDetails(offlineCardPresentDetails: OfflineCardPresentDetails?): ReadableMap? =
     offlineCardPresentDetails?.let {

--- a/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
@@ -145,6 +145,8 @@ internal fun mapFromDeviceType(type: DeviceType): String {
         DeviceType.WISEPAD_3S -> "wisePad3s"
         DeviceType.WISEPOS_E_DEVKIT -> "wisePosEDevkit"
         DeviceType.STRIPE_S700_DEVKIT -> "stripeS700Devkit"
+        DeviceType.STRIPE_S700 -> "stripeS700"
+        DeviceType.ETNA -> "etna"
     }
 }
 

--- a/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
@@ -136,17 +136,16 @@ internal fun mapFromDeviceType(type: DeviceType): String {
         DeviceType.COTS_DEVICE -> "cotsDevice"
         DeviceType.ETNA -> "etna"
         DeviceType.STRIPE_M2 -> "stripeM2"
+        DeviceType.STRIPE_S700 -> "stripeS700"
+        DeviceType.STRIPE_S700_DEVKIT -> "stripeS700Devkit"
         DeviceType.UNKNOWN -> "unknown"
         DeviceType.VERIFONE_P400 -> "verifoneP400"
-        DeviceType.WISEPAD_3 -> "wisePad3"
-        DeviceType.WISEPOS_E -> "wisePosE"
         DeviceType.WISECUBE -> "wisecube"
-        DeviceType.STRIPE_S700 -> "stripeS700"
+        DeviceType.WISEPAD_3 -> "wisePad3"
         DeviceType.WISEPAD_3S -> "wisePad3s"
+        DeviceType.WISEPOS_E -> "wisePosE"
         DeviceType.WISEPOS_E_DEVKIT -> "wisePosEDevkit"
-        DeviceType.STRIPE_S700_DEVKIT -> "stripeS700Devkit"
-        DeviceType.STRIPE_S700 -> "stripeS700"
-        DeviceType.ETNA -> "etna"
+
     }
 }
 

--- a/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
@@ -540,7 +540,7 @@ private fun mapFromOfflineDetails(offlineDetails: OfflineDetails?): ReadableMap?
 private fun mapFromAmountDetails(amountDetails: AmountDetails?): ReadableMap? =
     amountDetails?.let {
         nativeMapOf {
-            putMap("tip", nativeMapOf { putInt("amount", amountDetails.tip?.amount?.toInt() ?: 0) })
+            putMap("tip", nativeMapOf { putIntOrNull(this, "amount", amountDetails.tip?.amount?.toInt())})
         }
     }
 

--- a/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
@@ -579,8 +579,8 @@ fun mapFromReceiptDetails(receiptDetails: ReceiptDetails?): ReadableMap =
         putString("authorizationResponseCode", receiptDetails?.authorizationResponseCode)
         putString("cvm", receiptDetails?.cvm)
         putString("dedicatedFileName", receiptDetails?.dedicatedFileName)
-        putString("tsi", receiptDetails?.tsi)
-        putString("tvr", receiptDetails?.tvr)
+        putString("transactionStatusInformation", receiptDetails?.tsi)
+        putString("terminalVerificationResult", receiptDetails?.tvr)
     }
 
 internal fun mapFromNetworkStatus(status: NetworkStatus): String {

--- a/dev-app/src/App.tsx
+++ b/dev-app/src/App.tsx
@@ -70,7 +70,7 @@ export type RouteParamList = {
   CollectCardPayment: {
     simulated: boolean;
     discoveryMethod: Reader.DiscoveryMethod;
-    online: boolean;
+    deviceType: Reader.DeviceType;
   };
   RefundPayment: {
     simulated: boolean;

--- a/dev-app/src/App.tsx
+++ b/dev-app/src/App.tsx
@@ -70,6 +70,7 @@ export type RouteParamList = {
   CollectCardPayment: {
     simulated: boolean;
     discoveryMethod: Reader.DiscoveryMethod;
+    online: boolean;
   };
   RefundPayment: {
     simulated: boolean;

--- a/dev-app/src/screens/CollectCardPaymentScreen.tsx
+++ b/dev-app/src/screens/CollectCardPaymentScreen.tsx
@@ -166,7 +166,6 @@ export default function CollectCardPaymentScreen() {
     let paymentIntent: PaymentIntent.Type | undefined;
     let paymentIntentError: StripeError<CommonError> | undefined;
     if (discoveryMethod === 'internet' && online) {
-      console.log('api.createPaymentIntent');
       const resp = await api.createPaymentIntent({
         amount: Number(inputValues.amount),
         currency: inputValues.currency,
@@ -206,17 +205,31 @@ export default function CollectCardPaymentScreen() {
       paymentIntentError = response.error;
     } else {
       const offlineStatus = await getOfflineStatus();
-      let storedPaymentAmount = 0;
+      let sdkStoredPaymentAmount = 0;
       for (let currency in offlineStatus.sdk.offlinePaymentAmountsByCurrency) {
         if (currency === inputValues.currency) {
-          storedPaymentAmount =
+          sdkStoredPaymentAmount =
             offlineStatus.sdk.offlinePaymentAmountsByCurrency[currency];
         }
       }
+
+      let readerStoredPaymentAmount = 0;
+      if (offlineStatus.reader) {
+        for (let currency in offlineStatus.reader
+          .offlinePaymentAmountsByCurrency) {
+          if (currency === inputValues.currency) {
+            readerStoredPaymentAmount =
+              offlineStatus.reader.offlinePaymentAmountsByCurrency[currency];
+          }
+        }
+      }
+
       if (
         Number(inputValues.amount) >
           Number(inputValues.offlineModeTransactionLimit) ||
-        storedPaymentAmount >
+        sdkStoredPaymentAmount >
+          Number(inputValues.offlineModeStoredTransactionLimit) ||
+        readerStoredPaymentAmount >
           Number(inputValues.offlineModeStoredTransactionLimit)
       ) {
         inputValues.offlineBehavior = 'require_online';

--- a/dev-app/src/screens/CollectCardPaymentScreen.tsx
+++ b/dev-app/src/screens/CollectCardPaymentScreen.tsx
@@ -85,7 +85,7 @@ export default function CollectCardPaymentScreen() {
   const [tipEligibleAmount, setTipEligibleAmount] = useState('');
   const { params } =
     useRoute<RouteProp<RouteParamList, 'CollectCardPayment'>>();
-  const { simulated, discoveryMethod, online } = params;
+  const { simulated, discoveryMethod, deviceType } = params;
   const { addLogs, clearLogs, setCancel } = useContext(LogContext);
   const navigation = useNavigation();
 
@@ -164,11 +164,7 @@ export default function CollectCardPaymentScreen() {
     };
     let paymentIntent: PaymentIntent.Type | undefined;
     let paymentIntentError: StripeError<CommonError> | undefined;
-    if (
-      discoveryMethod === 'internet' &&
-      online &&
-      inputValues?.offlineBehavior === 'require_online'
-    ) {
+    if (deviceType === 'verifoneP400') {
       const resp = await api.createPaymentIntent({
         amount: Number(inputValues.amount),
         currency: inputValues.currency,

--- a/dev-app/src/screens/CollectCardPaymentScreen.tsx
+++ b/dev-app/src/screens/CollectCardPaymentScreen.tsx
@@ -165,7 +165,7 @@ export default function CollectCardPaymentScreen() {
     };
     let paymentIntent: PaymentIntent.Type | undefined;
     let paymentIntentError: StripeError<CommonError> | undefined;
-    console.log(deviceType);
+
     if (deviceType === 'verifoneP400') {
       const resp = await api.createPaymentIntent({
         amount: Number(inputValues.amount),

--- a/dev-app/src/screens/CollectCardPaymentScreen.tsx
+++ b/dev-app/src/screens/CollectCardPaymentScreen.tsx
@@ -165,6 +165,7 @@ export default function CollectCardPaymentScreen() {
     };
     let paymentIntent: PaymentIntent.Type | undefined;
     let paymentIntentError: StripeError<CommonError> | undefined;
+    console.log(deviceType);
     if (deviceType === 'verifoneP400') {
       const resp = await api.createPaymentIntent({
         amount: Number(inputValues.amount),

--- a/dev-app/src/screens/CollectCardPaymentScreen.tsx
+++ b/dev-app/src/screens/CollectCardPaymentScreen.tsx
@@ -96,7 +96,6 @@ export default function CollectCardPaymentScreen() {
     retrievePaymentIntent,
     cancelCollectPaymentMethod,
     setSimulatedCard,
-    getOfflineStatus,
   } = useStripeTerminal({
     onDidRequestReaderInput: (input) => {
       // @ts-ignore
@@ -204,36 +203,6 @@ export default function CollectCardPaymentScreen() {
       paymentIntent = response.paymentIntent;
       paymentIntentError = response.error;
     } else {
-      const offlineStatus = await getOfflineStatus();
-      let sdkStoredPaymentAmount = 0;
-      for (let currency in offlineStatus.sdk.offlinePaymentAmountsByCurrency) {
-        if (currency === inputValues.currency) {
-          sdkStoredPaymentAmount =
-            offlineStatus.sdk.offlinePaymentAmountsByCurrency[currency];
-        }
-      }
-
-      let readerStoredPaymentAmount = 0;
-      if (offlineStatus.reader) {
-        for (let currency in offlineStatus.reader
-          .offlinePaymentAmountsByCurrency) {
-          if (currency === inputValues.currency) {
-            readerStoredPaymentAmount =
-              offlineStatus.reader.offlinePaymentAmountsByCurrency[currency];
-          }
-        }
-      }
-
-      if (
-        Number(inputValues.amount) >
-          Number(inputValues.offlineModeTransactionLimit) ||
-        sdkStoredPaymentAmount >
-          Number(inputValues.offlineModeStoredTransactionLimit) ||
-        readerStoredPaymentAmount >
-          Number(inputValues.offlineModeStoredTransactionLimit)
-      ) {
-        inputValues.offlineBehavior = 'require_online';
-      }
       const response = await createPaymentIntent({
         amount: Number(inputValues.amount),
         currency: inputValues.currency,

--- a/dev-app/src/screens/CollectCardPaymentScreen.tsx
+++ b/dev-app/src/screens/CollectCardPaymentScreen.tsx
@@ -96,6 +96,7 @@ export default function CollectCardPaymentScreen() {
     retrievePaymentIntent,
     cancelCollectPaymentMethod,
     setSimulatedCard,
+    getOfflineStatus,
   } = useStripeTerminal({
     onDidRequestReaderInput: (input) => {
       // @ts-ignore
@@ -203,6 +204,35 @@ export default function CollectCardPaymentScreen() {
       paymentIntent = response.paymentIntent;
       paymentIntentError = response.error;
     } else {
+      const offlineStatus = await getOfflineStatus();
+      let sdkStoredPaymentAmount = 0;
+      for (let currency in offlineStatus.sdk.offlinePaymentAmountsByCurrency) {
+        if (currency === inputValues.currency) {
+          sdkStoredPaymentAmount =
+            offlineStatus.sdk.offlinePaymentAmountsByCurrency[currency];
+        }
+      }
+      let readerStoredPaymentAmount = 0;
+      if (offlineStatus.reader) {
+        for (let currency in offlineStatus.reader
+          .offlinePaymentAmountsByCurrency) {
+          if (currency === inputValues.currency) {
+            readerStoredPaymentAmount =
+              offlineStatus.reader.offlinePaymentAmountsByCurrency[currency];
+          }
+        }
+      }
+      if (
+        Number(inputValues.amount) >
+          Number(inputValues.offlineModeTransactionLimit) ||
+        sdkStoredPaymentAmount >
+          Number(inputValues.offlineModeStoredTransactionLimit) ||
+        readerStoredPaymentAmount >
+          Number(inputValues.offlineModeStoredTransactionLimit)
+      ) {
+        inputValues.offlineBehavior = 'require_online';
+      }
+
       const response = await createPaymentIntent({
         amount: Number(inputValues.amount),
         currency: inputValues.currency,

--- a/dev-app/src/screens/CollectCardPaymentScreen.tsx
+++ b/dev-app/src/screens/CollectCardPaymentScreen.tsx
@@ -164,7 +164,11 @@ export default function CollectCardPaymentScreen() {
     };
     let paymentIntent: PaymentIntent.Type | undefined;
     let paymentIntentError: StripeError<CommonError> | undefined;
-    if (discoveryMethod === 'internet' && online) {
+    if (
+      discoveryMethod === 'internet' &&
+      online &&
+      inputValues?.offlineBehavior === 'require_online'
+    ) {
       const resp = await api.createPaymentIntent({
         amount: Number(inputValues.amount),
         currency: inputValues.currency,

--- a/dev-app/src/screens/CollectCardPaymentScreen.tsx
+++ b/dev-app/src/screens/CollectCardPaymentScreen.tsx
@@ -85,7 +85,7 @@ export default function CollectCardPaymentScreen() {
   const [tipEligibleAmount, setTipEligibleAmount] = useState('');
   const { params } =
     useRoute<RouteProp<RouteParamList, 'CollectCardPayment'>>();
-  const { simulated, discoveryMethod } = params;
+  const { simulated, discoveryMethod, online } = params;
   const { addLogs, clearLogs, setCancel } = useContext(LogContext);
   const navigation = useNavigation();
 
@@ -165,7 +165,8 @@ export default function CollectCardPaymentScreen() {
     };
     let paymentIntent: PaymentIntent.Type | undefined;
     let paymentIntentError: StripeError<CommonError> | undefined;
-    if (discoveryMethod === 'internet') {
+    if (discoveryMethod === 'internet' && online) {
+      console.log('api.createPaymentIntent');
       const resp = await api.createPaymentIntent({
         amount: Number(inputValues.amount),
         currency: inputValues.currency,

--- a/dev-app/src/screens/DatabaseScreen.tsx
+++ b/dev-app/src/screens/DatabaseScreen.tsx
@@ -41,8 +41,6 @@ export default function DatabaseScreen() {
     getOfflinePaymentStatus();
   }, [getOfflineStatus]);
 
-  console.log(offlinePaymentStatus);
-
   return (
     <ScrollView style={styles.container}>
       <List bolded={false} topSpacing={false} title="READER SUMMARY">

--- a/dev-app/src/screens/DatabaseScreen.tsx
+++ b/dev-app/src/screens/DatabaseScreen.tsx
@@ -45,7 +45,7 @@ export default function DatabaseScreen() {
 
   return (
     <ScrollView style={styles.container}>
-      <List bolded={false} topSpacing={false} title="PUBLIC INTERFACE SUMMARY">
+      <List bolded={false} topSpacing={false} title="READER SUMMARY">
         {offlinePaymentStatus &&
         offlinePaymentStatus.reader &&
         offlinePaymentStatus.reader.offlinePaymentsCount > 0 ? (
@@ -72,8 +72,43 @@ export default function DatabaseScreen() {
       <Text style={styles.infoText}>
         {' '}
         {String(
-          offlinePaymentStatus && offlinePaymentStatus.reader
+          offlinePaymentStatus &&
+            offlinePaymentStatus.reader &&
+            offlinePaymentStatus.reader.offlinePaymentsCount
             ? offlinePaymentStatus.reader.offlinePaymentsCount
+            : 0
+        ) +
+          ' payment intent(s) for ' +
+          account?.settings?.dashboard.display_name}{' '}
+      </Text>
+      <List bolded={false} topSpacing={false} title="SDK SUMMARY">
+        {offlinePaymentStatus &&
+        offlinePaymentStatus.sdk.offlinePaymentsCount > 0 ? (
+          Object.keys(
+            offlinePaymentStatus.sdk.offlinePaymentAmountsByCurrency
+          ).map((key) => (
+            <ListItem
+              title={
+                getCurrencySymbols(key) +
+                ' ' +
+                (
+                  Number(
+                    offlinePaymentStatus.reader!
+                      .offlinePaymentAmountsByCurrency[key]
+                  ) / 100
+                ).toFixed(2)
+              }
+            />
+          ))
+        ) : (
+          <></>
+        )}
+      </List>
+      <Text style={styles.infoText}>
+        {' '}
+        {String(
+          offlinePaymentStatus && offlinePaymentStatus.sdk
+            ? offlinePaymentStatus.sdk.offlinePaymentsCount
             : 0
         ) +
           ' payment intent(s) for ' +

--- a/dev-app/src/screens/DatabaseScreen.tsx
+++ b/dev-app/src/screens/DatabaseScreen.tsx
@@ -91,8 +91,9 @@ export default function DatabaseScreen() {
                 ' ' +
                 (
                   Number(
-                    offlinePaymentStatus.reader!
-                      .offlinePaymentAmountsByCurrency[key]
+                    offlinePaymentStatus.sdk.offlinePaymentAmountsByCurrency[
+                      key
+                    ]
                   ) / 100
                 ).toFixed(2)
               }

--- a/dev-app/src/screens/DatabaseScreen.tsx
+++ b/dev-app/src/screens/DatabaseScreen.tsx
@@ -41,13 +41,16 @@ export default function DatabaseScreen() {
     getOfflinePaymentStatus();
   }, [getOfflineStatus]);
 
+  console.log(offlinePaymentStatus);
+
   return (
     <ScrollView style={styles.container}>
       <List bolded={false} topSpacing={false} title="PUBLIC INTERFACE SUMMARY">
         {offlinePaymentStatus &&
-        offlinePaymentStatus.sdk.offlinePaymentsCount > 0 ? (
+        offlinePaymentStatus.reader &&
+        offlinePaymentStatus.reader.offlinePaymentsCount > 0 ? (
           Object.keys(
-            offlinePaymentStatus.sdk.offlinePaymentAmountsByCurrency
+            offlinePaymentStatus.reader.offlinePaymentAmountsByCurrency
           ).map((key) => (
             <ListItem
               title={
@@ -55,9 +58,8 @@ export default function DatabaseScreen() {
                 ' ' +
                 (
                   Number(
-                    offlinePaymentStatus.sdk.offlinePaymentAmountsByCurrency[
-                      key
-                    ]
+                    offlinePaymentStatus.reader!
+                      .offlinePaymentAmountsByCurrency[key]
                   ) / 100
                 ).toFixed(2)
               }
@@ -70,8 +72,8 @@ export default function DatabaseScreen() {
       <Text style={styles.infoText}>
         {' '}
         {String(
-          offlinePaymentStatus
-            ? offlinePaymentStatus.sdk.offlinePaymentsCount
+          offlinePaymentStatus && offlinePaymentStatus.reader
+            ? offlinePaymentStatus.reader.offlinePaymentsCount
             : 0
         ) +
           ' payment intent(s) for ' +

--- a/dev-app/src/screens/HomeScreen.tsx
+++ b/dev-app/src/screens/HomeScreen.tsx
@@ -140,6 +140,7 @@ export default function HomeScreen() {
             navigation.navigate('CollectCardPaymentScreen', {
               simulated,
               discoveryMethod,
+              online,
             });
           }}
         />

--- a/dev-app/src/screens/HomeScreen.tsx
+++ b/dev-app/src/screens/HomeScreen.tsx
@@ -93,6 +93,7 @@ export default function HomeScreen() {
     ? '🔋' + batteryPercentage.toFixed(0) + '%'
     : '';
   const chargingStatus = connectedReader?.isCharging ? '🔌' : '';
+  const deviceType = connectedReader?.deviceType;
 
   useEffect(() => {
     const loadDiscSettings = async () => {
@@ -142,7 +143,7 @@ export default function HomeScreen() {
             navigation.navigate('CollectCardPaymentScreen', {
               simulated,
               discoveryMethod,
-              online,
+              deviceType,
             });
           }}
         />
@@ -216,7 +217,7 @@ export default function HomeScreen() {
             <Image source={icon} style={styles.image} />
           </View>
 
-          <Text style={styles.readerName}>{connectedReader.deviceType}</Text>
+          <Text style={styles.readerName}>{deviceType}</Text>
           <Text style={styles.connectionStatus}>
             Connected{simulated && <Text>, simulated</Text>}
           </Text>

--- a/dev-app/src/screens/HomeScreen.tsx
+++ b/dev-app/src/screens/HomeScreen.tsx
@@ -65,6 +65,7 @@ export default function HomeScreen() {
             '. ErrorMsg = ' +
             error.message;
         }
+        console.log(toastMsg);
         let toast = Toast.show(toastMsg, {
           duration: Toast.durations.LONG,
           position: Toast.positions.BOTTOM,

--- a/dev-app/src/screens/HomeScreen.tsx
+++ b/dev-app/src/screens/HomeScreen.tsx
@@ -57,13 +57,14 @@ export default function HomeScreen() {
         }, 3000);
       },
       onDidForwardPaymentIntent(paymentIntent, error) {
-        let toastMsg =
-          'Payment Intent ' +
-          paymentIntent.id +
-          ' forwarded. ErrorCode' +
-          error?.code +
-          '. ErrorMsg = ' +
-          error?.message;
+        let toastMsg = 'Payment Intent ' + paymentIntent.id + ' forwarded. ';
+        if (error) {
+          toastMsg +
+            'ErrorCode = ' +
+            error.code +
+            '. ErrorMsg = ' +
+            error.message;
+        }
         let toast = Toast.show(toastMsg, {
           duration: Toast.durations.LONG,
           position: Toast.positions.BOTTOM,

--- a/ios/Mappers.swift
+++ b/ios/Mappers.swift
@@ -432,11 +432,16 @@ class Mappers {
             offlineCardPresentDetails = mapFromOfflineCardPresentDetails(cardPresentDetails)
         }
         
+        var amountDetails: NSDictionary?
+        if let offlineAmountDetails = offlineDetails.amountDetails {
+            amountDetails = mapFromAmountDetails(offlineAmountDetails)
+        }
+        
         let result: NSDictionary = [
             "storedAt": offlineDetails.collectedAt ?? NSNull(),
             "requiresUpload": offlineDetails.requiresUpload,
             "cardPresentDetails": offlineCardPresentDetails ?? NSNull(),
-            "amountDetails": offlineDetails.amountDetails ?? NSNull()
+            "amountDetails": amountDetails ?? NSNull()
         ]
         
         return result

--- a/ios/Mappers.swift
+++ b/ios/Mappers.swift
@@ -71,7 +71,9 @@ class Mappers {
         case DeviceType.wisePosE: return "wisePosE"
         case DeviceType.wisePosEDevKit: return "wisePosEDevkit"
         case DeviceType.stripeS700DevKit: return "stripeS700Devkit"
+        case DeviceType.stripeS700: return "stripeS700"
         case DeviceType.appleBuiltIn: return "appleBuiltIn"
+        case DeviceType.etna: return "etna"
         default: return "unknown"
         }
     }

--- a/ios/Mappers.swift
+++ b/ios/Mappers.swift
@@ -138,6 +138,10 @@ class Mappers {
 
 
     class func mapFromPaymentIntent(_ paymentIntent: PaymentIntent, uuid: String) -> NSDictionary {
+        var offlineDetailsMap: NSDictionary?
+        if let offlineDetails = paymentIntent.offlineDetails {
+            offlineDetailsMap = mapFromOfflineDetails(offlineDetails)
+        }
         let result: NSDictionary = [
             "amount": paymentIntent.amount,
             "charges": mapFromCharges(paymentIntent.charges),
@@ -147,6 +151,7 @@ class Mappers {
             "id": paymentIntent.stripeId,
             "sdkUuid": uuid,
             "paymentMethodId": paymentIntent.paymentMethodId,
+            "offlineDetails": offlineDetailsMap ?? NSNull()
         ]
         return result
     }
@@ -418,6 +423,53 @@ class Mappers {
             "network": cardPresent.network,
             "wallet": walletMap
         ]
+        return result
+    }
+    
+    class func mapFromOfflineDetails(_ offlineDetails: OfflineDetails) -> NSDictionary {
+        var offlineCardPresentDetails: NSDictionary?
+        if let cardPresentDetails = offlineDetails.cardPresentDetails {
+            offlineCardPresentDetails = mapFromOfflineCardPresentDetails(cardPresentDetails)
+        }
+        
+        let result: NSDictionary = [
+            "storedAt": offlineDetails.collectedAt ?? NSNull(),
+            "requiresUpload": offlineDetails.requiresUpload,
+            "cardPresentDetails": offlineCardPresentDetails ?? NSNull(),
+            "amountDetails": offlineDetails.amountDetails ?? NSNull()
+        ]
+        
+        return result
+    }
+    
+    class func mapFromAmountDetails(_ amountDetails: SCPAmountDetails?) -> NSDictionary {
+        let amount: NSDictionary = [
+            "amount": amountDetails?.tip ?? NSNull(),
+        ]
+        
+        let result: NSDictionary = [
+            "tip": amount
+        ]
+        
+        return result
+    }
+    
+    class func mapFromOfflineCardPresentDetails(_ offlineCardPresentDetails: OfflineCardPresentDetails) -> NSDictionary {
+        var receiptDetailsMap: NSDictionary?
+        if let receiptDetails = offlineCardPresentDetails.receiptDetails {
+            receiptDetailsMap = mapFromReceiptDetails(receiptDetails)
+        }
+        
+        let result: NSDictionary = [
+            "brand": offlineCardPresentDetails.brand,
+            "cardholderName": offlineCardPresentDetails.cardholderName ?? NSNull(),
+            "expMonth": offlineCardPresentDetails.expMonth,
+            "expYear": offlineCardPresentDetails.expYear,
+            "last4": offlineCardPresentDetails.last4 ?? NSNull(),
+            "readMethod": offlineCardPresentDetails.readMethod,
+            "receiptDetails": receiptDetailsMap ?? NSNull()
+        ]
+        
         return result
     }
 

--- a/ios/Mappers.swift
+++ b/ios/Mappers.swift
@@ -62,18 +62,18 @@ class Mappers {
 
     class func mapFromDeviceType(_ type: DeviceType) -> String {
         switch type {
+        case DeviceType.appleBuiltIn: return "appleBuiltIn"
         case DeviceType.chipper1X: return "chipper1X"
         case DeviceType.chipper2X: return "chipper2X"
+        case DeviceType.etna: return "etna"
         case DeviceType.stripeM2: return "stripeM2"
+        case DeviceType.stripeS700: return "stripeS700"
+        case DeviceType.stripeS700DevKit: return "stripeS700Devkit"
         case DeviceType.verifoneP400: return "verifoneP400"
         case DeviceType.wiseCube: return "wiseCube"
         case DeviceType.wisePad3: return "wisePad3"
         case DeviceType.wisePosE: return "wisePosE"
         case DeviceType.wisePosEDevKit: return "wisePosEDevkit"
-        case DeviceType.stripeS700DevKit: return "stripeS700Devkit"
-        case DeviceType.stripeS700: return "stripeS700"
-        case DeviceType.appleBuiltIn: return "appleBuiltIn"
-        case DeviceType.etna: return "etna"
         default: return "unknown"
         }
     }
@@ -427,46 +427,46 @@ class Mappers {
         ]
         return result
     }
-    
+
     class func mapFromOfflineDetails(_ offlineDetails: OfflineDetails) -> NSDictionary {
         var offlineCardPresentDetails: NSDictionary?
         if let cardPresentDetails = offlineDetails.cardPresentDetails {
             offlineCardPresentDetails = mapFromOfflineCardPresentDetails(cardPresentDetails)
         }
-        
+
         var amountDetails: NSDictionary?
         if let offlineAmountDetails = offlineDetails.amountDetails {
             amountDetails = mapFromAmountDetails(offlineAmountDetails)
         }
-        
+
         let result: NSDictionary = [
             "storedAt": convertDateToUnixTimestamp(date: offlineDetails.collectedAt) ?? NSNull(),
             "requiresUpload": offlineDetails.requiresUpload,
             "cardPresentDetails": offlineCardPresentDetails ?? NSNull(),
             "amountDetails": amountDetails ?? NSNull()
         ]
-        
+
         return result
     }
-    
+
     class func mapFromAmountDetails(_ amountDetails: SCPAmountDetails?) -> NSDictionary {
         let amount: NSDictionary = [
             "amount": amountDetails?.tip ?? NSNull(),
         ]
-        
+
         let result: NSDictionary = [
             "tip": amount
         ]
-        
+
         return result
     }
-    
+
     class func mapFromOfflineCardPresentDetails(_ offlineCardPresentDetails: OfflineCardPresentDetails) -> NSDictionary {
         var receiptDetailsMap: NSDictionary?
         if let receiptDetails = offlineCardPresentDetails.receiptDetails {
             receiptDetailsMap = mapFromReceiptDetails(receiptDetails)
         }
-        
+
         let result: NSDictionary = [
             "brand": offlineCardPresentDetails.brand,
             "cardholderName": offlineCardPresentDetails.cardholderName ?? NSNull(),
@@ -476,7 +476,7 @@ class Mappers {
             "readMethod": mapFromReadMethod(offlineCardPresentDetails.readMethod),
             "receiptDetails": receiptDetailsMap ?? NSNull()
         ]
-        
+
         return result
     }
 
@@ -659,7 +659,7 @@ class Mappers {
 
         return(["sdk": sdkDict, "reader": readerDict])
     }
-    
+
     class func mapFromReaderTextToSpeechStatus(_ status: ReaderTextToSpeechStatus) -> String {
         switch status {
         case ReaderTextToSpeechStatus.off: return "off"
@@ -668,12 +668,12 @@ class Mappers {
         default: return "unknown"
         }
     }
-    
+
     class func mapFromReaderSettings(_ readerSettings: ReaderSettings) -> NSDictionary {
         var accessibility: [String : Any] = [
             "textToSpeechStatus": mapFromReaderTextToSpeechStatus(readerSettings.accessibility.textToSpeechStatus),
         ]
-        
+
         let errorDic: NSDictionary
         if let error = readerSettings.accessibility.error as NSError? {
             errorDic = [
@@ -685,7 +685,7 @@ class Mappers {
 
         return(["accessibility": accessibility])
     }
-    
+
     class func mapFromReaderDisconnectReason(_ reason: DisconnectReason) -> String {
         switch reason {
         case DisconnectReason.disconnectRequested: return "disconnectRequested"
@@ -697,7 +697,7 @@ class Mappers {
         default: return "unknown"
         }
     }
-    
+
     class func mapFromReadMethod(_ readMethod: SCPReadMethod) -> String {
         switch readMethod {
         case SCPReadMethod.contactEMV: return "contactEMV"
@@ -708,7 +708,7 @@ class Mappers {
         default: return "unknown"
         }
     }
-    
+
     class func mapFromCollectInputs(_ results: [CollectInputsResult]) -> NSDictionary {
         var collectInputResults: [String : Any] = [:]
         for result in results {
@@ -738,7 +738,7 @@ class Mappers {
                 collectInputResults["selectionResult"] = selectionResult
             }
         }
-        
+
         return (["collectInputResults": collectInputResults])
     }
 }

--- a/ios/Mappers.swift
+++ b/ios/Mappers.swift
@@ -471,7 +471,7 @@ class Mappers {
             "expMonth": offlineCardPresentDetails.expMonth,
             "expYear": offlineCardPresentDetails.expYear,
             "last4": offlineCardPresentDetails.last4 ?? NSNull(),
-            "readMethod": offlineCardPresentDetails.readMethod,
+            "readMethod": mapFromReadMethod(offlineCardPresentDetails.readMethod),
             "receiptDetails": receiptDetailsMap ?? NSNull()
         ]
         
@@ -692,6 +692,17 @@ class Mappers {
         case DisconnectReason.criticallyLowBattery: return "criticallyLowBattery"
         case DisconnectReason.poweredOff: return "poweredOff"
         case DisconnectReason.bluetoothDisabled: return "bluetoothDisabled"
+        default: return "unknown"
+        }
+    }
+    
+    class func mapFromReadMethod(_ readMethod: SCPReadMethod) -> String {
+        switch readMethod {
+        case SCPReadMethod.contactEMV: return "contactEMV"
+        case SCPReadMethod.contactlessEMV: return "contactlessEMV"
+        case SCPReadMethod.contactlessMagstripeMode: return "contactlessMagstripeMode"
+        case SCPReadMethod.magneticStripeFallback: return "magneticStripeFallback"
+        case SCPReadMethod.magneticStripeTrack2: return "magneticStripeTrack2"
         default: return "unknown"
         }
     }

--- a/ios/Mappers.swift
+++ b/ios/Mappers.swift
@@ -438,7 +438,7 @@ class Mappers {
         }
         
         let result: NSDictionary = [
-            "storedAt": offlineDetails.collectedAt ?? NSNull(),
+            "storedAt": convertDateToUnixTimestamp(date: offlineDetails.collectedAt) ?? NSNull(),
             "requiresUpload": offlineDetails.requiresUpload,
             "cardPresentDetails": offlineCardPresentDetails ?? NSNull(),
             "amountDetails": amountDetails ?? NSNull()

--- a/src/hooks/useStripeTerminal.tsx
+++ b/src/hooks/useStripeTerminal.tsx
@@ -869,7 +869,7 @@ export function useStripeTerminal(props?: Props) {
       throw Error(NOT_INITIALIZED_ERROR_MESSAGE);
     }
     const response = await getOfflineStatus();
-    if (response.reader?.networkStatus) {
+    if (!response.reader?.networkStatus) {
       response.reader = undefined;
     }
     return response;

--- a/src/types/PaymentIntent.ts
+++ b/src/types/PaymentIntent.ts
@@ -1,4 +1,4 @@
-import type { Charge, PaymentMethod } from './';
+import type { Charge, OfflineDetails, PaymentMethod } from './';
 
 export namespace PaymentIntent {
   export interface Type {
@@ -11,6 +11,7 @@ export namespace PaymentIntent {
     sdkUuid: string;
     paymentMethodId: string;
     paymentMethod: PaymentMethod.Type;
+    offlineDetails: OfflineDetails;
   }
 
   export type Status =

--- a/src/types/Reader.ts
+++ b/src/types/Reader.ts
@@ -90,8 +90,10 @@ export namespace Reader {
     | 'wisePad3s'
     | 'wisePadEDevkit'
     | 'stripeS700Devkit'
+    | 'stripeS700'
     | 'cotsDevice'
-    | 'appleBuiltIn';
+    | 'appleBuiltIn'
+    | 'etna';
 
   export type InputOptions = 'insertCard' | 'swipeCard' | 'tapCard';
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -431,7 +431,7 @@ export enum SelectionButtonStyle {
 export type OfflineDetails = {
   storedAt: string;
   requiresUpload: boolean;
-  cardPresentDetails: CardPresentDetails;
+  cardPresentDetails: OfflineCardPresentDetails;
   amountDetails: AmountDetails;
 };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -281,8 +281,8 @@ export type ReceiptDetails = {
   authorizationResponseCode: string;
   cvm: string;
   dedicatedFileName: string;
-  tsi: string;
-  tvr: string;
+  terminalVerificationResult: string;
+  transactionStatusInformation: string;
 };
 
 export type Wallet = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -427,3 +427,28 @@ export enum SelectionButtonStyle {
   PRIMARY = 'PRIMARY',
   SECONDARY = 'CanSECONDARYceled',
 }
+
+export type OfflineDetails = {
+  storedAt: string;
+  requiresUpload: boolean;
+  cardPresentDetails: CardPresentDetails;
+  amountDetails: AmountDetails;
+} 
+
+export type OfflineCardPresentDetails = {
+  brand: string;
+  cardholderName: string;
+  expMonth: number;
+  expYear: number;
+  last4: string;
+  readMethod: string;
+  receiptDetails: ReceiptDetails;
+}
+
+export type AmountDetails = {
+  tip: Amount;
+}
+
+export type Amount = {
+  amount: number;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -433,7 +433,7 @@ export type OfflineDetails = {
   requiresUpload: boolean;
   cardPresentDetails: CardPresentDetails;
   amountDetails: AmountDetails;
-} 
+};
 
 export type OfflineCardPresentDetails = {
   brand: string;
@@ -443,12 +443,12 @@ export type OfflineCardPresentDetails = {
   last4: string;
   readMethod: string;
   receiptDetails: ReceiptDetails;
-}
+};
 
 export type AmountDetails = {
   tip: Amount;
-}
+};
 
 export type Amount = {
   amount: number;
-}
+};


### PR DESCRIPTION
## Summary
Adds offline mode support for sPOS readers:
- Updates dev-app to create PIs client-side for sPOS readers 
- Adds offlineDetails to native mappers
<!-- Simple summary of what was changed. -->

## Motivation

<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

## Testing
![image](https://github.com/stripe/stripe-terminal-react-native/assets/69359432/38e2cfa3-2b00-4fdf-8e30-c4971d602ebf)


<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
