### PR TITLE
Timeout for BT discovery scan

### DIFF
--- a/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
@@ -206,14 +206,14 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
         discoverCancelable = terminal.discoverReaders(
             config = when (discoveryMethod) {
                 DiscoveryMethod.BLUETOOTH_SCAN -> DiscoveryConfiguration.BluetoothDiscoveryConfiguration(
-                    0,
+                    getInt(params, "timeout") ?: 0,
                     getBoolean(params, "simulated")
                 )
                 DiscoveryMethod.INTERNET -> DiscoveryConfiguration.InternetDiscoveryConfiguration(
                     isSimulated = getBoolean(params, "simulated")
                 )
                 DiscoveryMethod.USB -> DiscoveryConfiguration.UsbDiscoveryConfiguration(
-                    0,
+                    getInt(params, "timeout") ?: 0,
                     getBoolean(params, "simulated")
                 )
                 DiscoveryMethod.HANDOFF -> DiscoveryConfiguration.HandoffDiscoveryConfiguration()

--- a/dev-app/src/screens/DiscoverReadersScreen.tsx
+++ b/dev-app/src/screens/DiscoverReadersScreen.tsx
@@ -153,6 +153,7 @@ export default function DiscoverReadersScreen() {
     const { error: discoverReadersError } = await discoverReaders({
       discoveryMethod,
       simulated,
+      timeout: 0,
     });
 
     if (discoverReadersError) {

--- a/ios/Mappers.swift
+++ b/ios/Mappers.swift
@@ -122,10 +122,10 @@ class Mappers {
         return DiscoveryMethod.internet
     }
 
-    class func mapToDiscoveryConfiguration(_ discoveryMethod: String?, simulated: Bool) throws-> DiscoveryConfiguration {
+    class func mapToDiscoveryConfiguration(_ discoveryMethod: String?, simulated: Bool, timeout: UInt) throws-> DiscoveryConfiguration {
         switch discoveryMethod {
         case "bluetoothScan":
-            return try BluetoothScanDiscoveryConfigurationBuilder().setSimulated(simulated).build()
+            return try BluetoothScanDiscoveryConfigurationBuilder().setSimulated(simulated).setTimeout(timeout).build()
         case "bluetoothProximity":
             return try BluetoothProximityDiscoveryConfigurationBuilder().setSimulated(simulated).build()
         case "internet":
@@ -134,7 +134,7 @@ class Mappers {
             return try LocalMobileDiscoveryConfigurationBuilder().setSimulated(simulated).build()
         @unknown default:
             print("⚠️ Unknown discovery method! Defaulting to Bluetooth Scan.")
-            return try BluetoothScanDiscoveryConfigurationBuilder().setSimulated(simulated).build()
+            return try BluetoothScanDiscoveryConfigurationBuilder().setSimulated(simulated).setTimeout(timeout).build()
         }
     }
 

--- a/ios/StripeTerminalReactNative.swift
+++ b/ios/StripeTerminalReactNative.swift
@@ -170,10 +170,11 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, BluetoothRe
     func discoverReaders(params: NSDictionary, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
         let simulated = params["simulated"] as? Bool
         let discoveryMethod = params["discoveryMethod"] as? String
-
+        let timeout = params["timeout"] as? UInt ?? 0
+        
         let config: DiscoveryConfiguration
         do {
-            config = try Mappers.mapToDiscoveryConfiguration(discoveryMethod, simulated: simulated ?? false)
+            config = try Mappers.mapToDiscoveryConfiguration(discoveryMethod, simulated: simulated ?? false, timeout: timeout)
         } catch {
             resolve(Errors.createError(nsError: error as NSError))
             return

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,7 +22,7 @@ export type LogLevelIOS = 'none' | 'verbose';
 export type LogLevelAndroid = 'none' | 'verbose' | 'error' | 'warning';
 
 export type DiscoverReadersParams = {
-  timeout: number;
+  timeout?: number;
   simulated?: boolean;
   discoveryMethod: Reader.DiscoveryMethod;
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,6 +22,7 @@ export type LogLevelIOS = 'none' | 'verbose';
 export type LogLevelAndroid = 'none' | 'verbose' | 'error' | 'warning';
 
 export type DiscoverReadersParams = {
+  timeout: number;
   simulated?: boolean;
   discoveryMethod: Reader.DiscoveryMethod;
 };


### PR DESCRIPTION
## Summary

Add timeout param for BT discovery scan.

## Motivation

To support setting bluetooth discovery scan timeout.

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
