### PR TITLE
[TERMINAL] Cache locations for offline mode pairing

### DIFF
--- a/dev-app/src/AppContext.ts
+++ b/dev-app/src/AppContext.ts
@@ -15,4 +15,6 @@ export const AppContext = React.createContext<IAppContext>({
   setLastSuccessfulPaymentIntentId: (_id) => null,
   autoReconnectOnUnexpectedDisconnect: false,
   setAutoReconnectOnUnexpectedDisconnect: (_b) => null,
+  cachedLocations: [],
+  setCachedLocations: (_locations) => null,
 });

--- a/dev-app/src/Root.tsx
+++ b/dev-app/src/Root.tsx
@@ -1,6 +1,9 @@
 import React, { useState, useCallback, useEffect } from 'react';
 
-import { StripeTerminalProvider } from '@stripe/stripe-terminal-react-native';
+import {
+  StripeTerminalProvider,
+  Location,
+} from '@stripe/stripe-terminal-react-native';
 import App from './App';
 import { AppContext, api } from './AppContext';
 import type { IAccount } from './types';
@@ -22,6 +25,9 @@ export default function Root() {
     autoReconnectOnUnexpectedDisconnect,
     setAutoReconnectOnUnexpectedDisconnect,
   ] = useState<boolean | false>(false);
+
+  const [cachedLocations, setCachedLocations] = useState<Location[]>([]);
+
 
   useEffect(() => {
     // var is a string in CI
@@ -94,6 +100,8 @@ export default function Root() {
         autoReconnectOnUnexpectedDisconnect,
         setAutoReconnectOnUnexpectedDisconnect: (b) =>
           setAutoReconnectOnUnexpectedDisconnect(b),
+        cachedLocations,
+        setCachedLocations: (locations) => setCachedLocations(locations),
       }}
     >
       <StripeTerminalProvider

--- a/dev-app/src/Root.tsx
+++ b/dev-app/src/Root.tsx
@@ -28,7 +28,6 @@ export default function Root() {
 
   const [cachedLocations, setCachedLocations] = useState<Location[]>([]);
 
-
   useEffect(() => {
     // var is a string in CI
     if (process.env.IS_CI === 'true') {

--- a/dev-app/src/screens/LocationListScreen.tsx
+++ b/dev-app/src/screens/LocationListScreen.tsx
@@ -18,10 +18,7 @@ import type { RouteParamList } from '../App';
 import { AppContext } from '../AppContext';
 
 export default function LocationListScreen() {
-  const {
-    cachedLocations,
-    setCachedLocations
-  } = useContext(AppContext);
+  const { cachedLocations, setCachedLocations } = useContext(AppContext);
 
   const navigation = useNavigation();
   const { params } = useRoute<RouteProp<RouteParamList, 'LocationList'>>();
@@ -44,12 +41,11 @@ export default function LocationListScreen() {
         setList(locations);
         setCachedLocations(locations);
       } else {
-        console.log("setting cached locations")
         setList(cachedLocations);
       }
     }
     init();
-  }, [getLocations]);
+  }, [getLocations, setCachedLocations, cachedLocations]);
 
   const renderItem = (item: Location) => (
     <ListItem

--- a/dev-app/src/screens/LocationListScreen.tsx
+++ b/dev-app/src/screens/LocationListScreen.tsx
@@ -1,5 +1,5 @@
 import { RouteProp, useNavigation, useRoute } from '@react-navigation/core';
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import {
   ActivityIndicator,
   FlatList,
@@ -15,8 +15,14 @@ import { colors } from '../colors';
 import ListItem from '../components/ListItem';
 
 import type { RouteParamList } from '../App';
+import { AppContext } from '../AppContext';
 
 export default function LocationListScreen() {
+  const {
+    cachedLocations,
+    setCachedLocations
+  } = useContext(AppContext);
+
   const navigation = useNavigation();
   const { params } = useRoute<RouteProp<RouteParamList, 'LocationList'>>();
 
@@ -36,6 +42,10 @@ export default function LocationListScreen() {
       const { locations } = await getLocations({ limit: 20 });
       if (locations) {
         setList(locations);
+        setCachedLocations(locations);
+      } else {
+        console.log("setting cached locations")
+        setList(cachedLocations);
       }
     }
     init();

--- a/dev-app/src/types.ts
+++ b/dev-app/src/types.ts
@@ -1,5 +1,6 @@
 import type { Stripe } from 'stripe';
 import type { Api as IApi } from './api/api';
+import type { Location } from '@stripe/stripe-terminal-react-native';
 
 export type IAccount = Stripe.Account & { secretKey: string };
 
@@ -17,6 +18,8 @@ export type IAppContext = {
   setLastSuccessfulPaymentIntentId: (id: string) => void;
   autoReconnectOnUnexpectedDisconnect: boolean | false;
   setAutoReconnectOnUnexpectedDisconnect: (b: boolean) => void;
+  cachedLocations: Array<Location>;
+  setCachedLocations: (locations: Array<Location>) => void;
 };
 
 export type IShortAccount = {


### PR DESCRIPTION
## Summary
- To support offline pairing of unseen readers, we need to cache the location list so that the user can select a location while offline. (technically we can also allow the user to manually input the location id, but this is easier to use)

Flow:
1. user pairs a bluetooth reader online (with location A)
2. user disconnects
3. user goes offline
4. user pairs a different bluetooth reader that has never been paired before to the app (of the same model) with the same location (location A)
5. reader is successfully paired

## Motivation

Allow testing for unseen readers offline

## Testing

- [x] I tested this manually <- is there a way to test a more formal build, like without the react native stuff (hot reloading, etc.)
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
