### PR TITLE
Support Invalid location registration for mPOS readers.

### DIFF
--- a/dev-app/src/screens/DiscoverReadersScreen.tsx
+++ b/dev-app/src/screens/DiscoverReadersScreen.tsx
@@ -291,37 +291,41 @@ export default function DiscoverReadersScreen() {
       testID="discovery-readers-screen"
       contentContainerStyle={styles.container}
     >
-      <List title="SELECT LOCATION">
-        <ListItem
-          onPress={() => {
-            if (!simulated) {
-              navigation.navigate('LocationListScreen', {
-                onSelect: (location: Location) => setSelectedLocation(location),
-              });
+      {discoveryMethod != 'internet' && (
+        <List title="SELECT LOCATION">
+          <ListItem
+            onPress={() => {
+              if (!simulated) {
+                navigation.navigate('LocationListScreen', {
+                  onSelect: (location: Location) =>
+                    setSelectedLocation(location),
+                  showDummyLocation: true,
+                });
+              }
+            }}
+            disabled={simulated}
+            title={
+              simulated
+                ? 'Mock simulated reader location'
+                : selectedLocation?.displayName || 'No location selected'
             }
-          }}
-          disabled={simulated}
-          title={
-            simulated
-              ? 'Mock simulated reader location'
-              : selectedLocation?.displayName || 'No location selected'
-          }
-        />
+          />
 
-        {simulated ? (
-          <Text style={styles.infoText}>
-            Simulated readers are always registered to the mock simulated
-            location.
-          </Text>
-        ) : (
-          <Text style={styles.infoText}>
-            Bluetooth readers must be registered to a location during the
-            connection process. If you do not select a location, the reader will
-            attempt to register to the same location it was registered to during
-            the previous connection.
-          </Text>
-        )}
-      </List>
+          {simulated ? (
+            <Text style={styles.infoText}>
+              Simulated readers are always registered to the mock simulated
+              location.
+            </Text>
+          ) : (
+            <Text style={styles.infoText}>
+              Bluetooth readers must be registered to a location during the
+              connection process. If you do not select a location, the reader
+              will attempt to register to the same location it was registered to
+              during the previous connection.
+            </Text>
+          )}
+        </List>
+      )}
 
       {simulated && discoveryMethod !== 'internet' && (
         <List title="SIMULATED UPDATE PLAN">


### PR DESCRIPTION
## Summary

Support Invalid location registration for mPOS readers.

## Motivation

<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
