### PR TITLE
Fix PaymentMethod mapping 

### DIFF
--- a/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
@@ -521,6 +521,7 @@ internal fun mapFromPaymentMethod(paymentMethod: PaymentMethod?): ReadableMap? =
                 mapFromCardPresentDetails(it.interacPresentDetails)
             )
             putString("customer", it.customer)
+            putString("id", it.id)
             putMap(
                 "metadata",
                 nativeMapOf {

--- a/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
@@ -509,12 +509,18 @@ internal fun mapFromCardDetails(cardDetails: CardDetails?): ReadableMap = native
     putString("last4", cardDetails?.last4)
 }
 
-internal fun mapFromPaymentMethod(paymentMethod: PaymentMethod): ReadableMap = nativeMapOf {
-    putString("id", paymentMethod.id)
-    putString("customer", paymentMethod.customer)
-    putBoolean("livemode", paymentMethod.livemode)
-    putMap("cardDetails", mapFromCardDetails(paymentMethod.cardDetails))
-}
+private fun mapFromPaymentMethod(paymentMethod: PaymentMethod?): ReadableMap =
+    nativeMapOf {
+        putMap(
+            "cardPresentDetails",
+            mapFromCardPresentDetails(paymentMethod?.cardPresentDetails)
+        )
+        putMap(
+            "interacPresentDetails",
+            mapFromCardPresentDetails(paymentMethod?.interacPresentDetails)
+        )
+        putString("type", paymentMethod?.type)
+    }
 
 private fun <T> Iterable<T>.collectToWritableArray(transform: (T) -> ReadableMap?): ReadableArray =
     fold(nativeArrayOf()) { writableArray, item ->

--- a/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
@@ -509,17 +509,27 @@ internal fun mapFromCardDetails(cardDetails: CardDetails?): ReadableMap = native
     putString("last4", cardDetails?.last4)
 }
 
-internal fun mapFromPaymentMethod(paymentMethod: PaymentMethod?): ReadableMap =
-    nativeMapOf {
-        putMap(
-            "cardPresentDetails",
-            mapFromCardPresentDetails(paymentMethod?.cardPresentDetails)
-        )
-        putMap(
-            "interacPresentDetails",
-            mapFromCardPresentDetails(paymentMethod?.interacPresentDetails)
-        )
-        putString("customer", paymentMethod?.customer)
+internal fun mapFromPaymentMethod(paymentMethod: PaymentMethod?): ReadableMap? =
+    paymentMethod?.let {
+        nativeMapOf {
+            putMap(
+                "cardPresentDetails",
+                mapFromCardPresentDetails(it.cardPresentDetails)
+            )
+            putMap(
+                "interacPresentDetails",
+                mapFromCardPresentDetails(it.interacPresentDetails)
+            )
+            putString("customer", it.customer)
+            putMap(
+                "metadata",
+                nativeMapOf {
+                    it.metadata?.map { entry ->
+                        putString(entry.key, entry.value)
+                    }
+                }
+            )
+        }
     }
 
 private fun <T> Iterable<T>.collectToWritableArray(transform: (T) -> ReadableMap?): ReadableArray =

--- a/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
@@ -509,7 +509,7 @@ internal fun mapFromCardDetails(cardDetails: CardDetails?): ReadableMap = native
     putString("last4", cardDetails?.last4)
 }
 
-private fun mapFromPaymentMethod(paymentMethod: PaymentMethod?): ReadableMap =
+internal fun mapFromPaymentMethod(paymentMethod: PaymentMethod?): ReadableMap =
     nativeMapOf {
         putMap(
             "cardPresentDetails",
@@ -519,7 +519,7 @@ private fun mapFromPaymentMethod(paymentMethod: PaymentMethod?): ReadableMap =
             "interacPresentDetails",
             mapFromCardPresentDetails(paymentMethod?.interacPresentDetails)
         )
-        putString("type", paymentMethod?.type)
+        putString("customer", paymentMethod?.customer)
     }
 
 private fun <T> Iterable<T>.collectToWritableArray(transform: (T) -> ReadableMap?): ReadableArray =

--- a/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
@@ -549,28 +549,30 @@ internal fun mapFromPaymentMethodDetailsType(type: PaymentMethodType?): String {
     }
 }
 
-private fun mapFromCardPresentDetails(cardPresentDetails: CardPresentDetails?): ReadableMap =
-    nativeMapOf {
-        putString("brand", cardPresentDetails?.brand)
-        putString("cardholderName", cardPresentDetails?.cardholderName)
-        putString("country", cardPresentDetails?.country)
-        putString("emvAuthData", cardPresentDetails?.emvAuthData)
-        putIntOrNull(this, "expMonth", cardPresentDetails?.expMonth)
-        putIntOrNull(this, "expYear", cardPresentDetails?.expYear)
-        putString("funding", cardPresentDetails?.funding)
-        putString("generatedCard", cardPresentDetails?.generatedCard)
-        putString("last4", cardPresentDetails?.last4)
-        putString("readMethod", cardPresentDetails?.readMethod)
-        putMap("receiptDetails", mapFromReceiptDetails(cardPresentDetails?.receiptDetails))
-        putString("issuer", cardPresentDetails?.issuer)
-        putString("iin", cardPresentDetails?.iin)
-        putString("network", cardPresentDetails?.network)
-        putString("description", cardPresentDetails?.description)
-        putMap("wallet", mapFromWallet(cardPresentDetails?.wallet))
-        putArray(
-            "preferredLocales",
-            convertListToReadableArray(cardPresentDetails?.preferredLocales)
-        )
+private fun mapFromCardPresentDetails(cardPresentDetails: CardPresentDetails?): ReadableMap? =
+    cardPresentDetails?.let {
+        nativeMapOf {
+            putString("brand", it.brand)
+            putString("cardholderName", it.cardholderName)
+            putString("country", it.country)
+            putString("emvAuthData", it.emvAuthData)
+            putIntOrNull(this, "expMonth", it.expMonth)
+            putIntOrNull(this, "expYear", it.expYear)
+            putString("funding", it.funding)
+            putString("generatedCard", it.generatedCard)
+            putString("last4", it.last4)
+            putString("readMethod", it.readMethod)
+            putMap("receiptDetails", mapFromReceiptDetails(it.receiptDetails))
+            putString("issuer", it.issuer)
+            putString("iin", it.iin)
+            putString("network", it.network)
+            putString("description", it.description)
+            putMap("wallet", mapFromWallet(it.wallet))
+            putArray(
+                "preferredLocales",
+                convertListToReadableArray(it.preferredLocales)
+            )
+        }
     }
 
 private fun mapFromOfflineDetails(offlineDetails: OfflineDetails?): ReadableMap? =

--- a/ios/Mappers.swift
+++ b/ios/Mappers.swift
@@ -3,15 +3,15 @@ import StripeTerminal
 class Mappers {
     class func mapFromReaders(_ readers: [Reader]) -> [NSDictionary] {
         var readersList: [NSDictionary] = []
-        
+
         for reader in readers {
             let result = mapFromReader(reader)
             readersList.append(result)
         }
-        
+
         return readersList
     }
-    
+
     class func mapFromReader(_ reader: Reader) -> NSDictionary {
         let result: NSDictionary = [
             "label": reader.label ?? NSNull(),
@@ -32,7 +32,7 @@ class Mappers {
         ]
         return result
     }
-    
+
     class func mapFromLocationStatus(_ status: LocationStatus) -> String {
         switch status {
         case LocationStatus.notSet: return "notSet"
@@ -41,7 +41,7 @@ class Mappers {
         default: return "unknown"
         }
     }
-    
+
     class func mapFromReaderNetworkStatus(_ status: ReaderNetworkStatus) -> String {
         switch status {
         case ReaderNetworkStatus.offline: return "offline"
@@ -49,7 +49,7 @@ class Mappers {
         default: return "unknown"
         }
     }
-    
+
     class func mapFromBatteryStatus(_ status: BatteryStatus) -> String {
         switch status {
         case BatteryStatus.critical: return "critical"
@@ -59,7 +59,7 @@ class Mappers {
         default: return "unknown"
         }
     }
-    
+
     class func mapFromDeviceType(_ type: DeviceType) -> String {
         switch type {
         case DeviceType.appleBuiltIn: return "appleBuiltIn"
@@ -77,7 +77,7 @@ class Mappers {
         default: return "unknown"
         }
     }
-    
+
     class func mapToDeviceType(_ type: String) -> DeviceType? {
         switch type {
         case "appleBuiltIn": return DeviceType.appleBuiltIn
@@ -95,12 +95,12 @@ class Mappers {
         default: return nil
         }
     }
-    
+
     class func mapToCartLineItem(_ cartLineItem: NSDictionary) -> CartLineItem? {
         guard let displayName = cartLineItem["displayName"] as? String else { return nil }
         guard let quantity = cartLineItem["quantity"] as? NSNumber else { return nil }
         guard let amount = cartLineItem["amount"] as? NSNumber else { return nil }
-        
+
         do {
             let lineItem = try CartLineItemBuilder(displayName: displayName)
                 .setQuantity(Int(truncating: quantity))
@@ -112,10 +112,10 @@ class Mappers {
             return nil
         }
     }
-    
+
     class func mapToCartLineItems(_ cartLineItems: NSArray) -> [CartLineItem] {
         var items = [CartLineItem]()
-        
+
         cartLineItems.forEach {
             if let item = $0 as? NSDictionary {
                 if let lineItem = Mappers.mapToCartLineItem(item) {
@@ -125,8 +125,8 @@ class Mappers {
         }
         return items
     }
-    
-    
+
+
     class func mapToDiscoveryMethod(_ discoveryMethod: String?) -> DiscoveryMethod {
         if let method = discoveryMethod {
             switch method {
@@ -139,7 +139,7 @@ class Mappers {
         }
         return DiscoveryMethod.internet
     }
-    
+
     class func mapToDiscoveryConfiguration(_ discoveryMethod: String?, simulated: Bool, timeout: UInt) throws-> DiscoveryConfiguration {
         switch discoveryMethod {
         case "bluetoothScan":
@@ -155,7 +155,7 @@ class Mappers {
             return try BluetoothScanDiscoveryConfigurationBuilder().setSimulated(simulated).setTimeout(timeout).build()
         }
     }
-    
+
     class func mapFromCaptureMethod(_ captureMethod: CaptureMethod) -> String {
         switch captureMethod {
         case CaptureMethod.manual: return "manual"
@@ -163,7 +163,7 @@ class Mappers {
         default: return "unknown"
         }
     }
-    
+
     class func mapFromPaymentIntent(_ paymentIntent: PaymentIntent, uuid: String) -> NSDictionary {
         var offlineDetailsMap: NSDictionary?
         if let offlineDetails = paymentIntent.offlineDetails {
@@ -197,7 +197,7 @@ class Mappers {
         ]
         return result
     }
-    
+
     class func mapFromSetupIntent(_ setupIntent: SetupIntent, uuid: String) -> NSDictionary {
         var metadataMap: NSDictionary?
         if let metadata = setupIntent.metadata {
@@ -216,7 +216,7 @@ class Mappers {
         ]
         return result
     }
-    
+
     class func mapFromSetupIntentUsage(_ usage: SetupIntentUsage) -> String {
         switch usage {
         case SetupIntentUsage.offSession: return "offSession"
@@ -224,7 +224,7 @@ class Mappers {
         default: return "unknown"
         }
     }
-    
+
     class func mapFromSetupAttempt(_ attempt: SetupAttempt?) -> NSDictionary? {
         guard let unwrappedAttempt = attempt else {
             return nil
@@ -242,7 +242,7 @@ class Mappers {
         ]
         return result
     }
-    
+
     class func mapFromSetupAttemptPaymentMethodDetails(_ details: SetupAttemptPaymentMethodDetails?) -> NSDictionary? {
         guard let unwrappedDetails = details else {
             return nil
@@ -254,7 +254,7 @@ class Mappers {
         ]
         return result
     }
-    
+
     class func mapFromSetupAttemptCardPresentDetails(_ details: SetupAttemptCardPresentDetails?) -> NSDictionary? {
         guard let unwrappedDetails = details else {
             return nil
@@ -265,8 +265,8 @@ class Mappers {
         ]
         return result
     }
-    
-    
+
+
     class func mapFromSetupIntentStatus(_ status: SetupIntentStatus) -> String {
         switch status {
         case SetupIntentStatus.canceled: return "canceled"
@@ -278,7 +278,7 @@ class Mappers {
         default: return "unknown"
         }
     }
-    
+
     class func mapFromPaymentIntentStatus(_ status: PaymentIntentStatus) -> String {
         switch status {
         case PaymentIntentStatus.canceled: return "canceled"
@@ -290,7 +290,7 @@ class Mappers {
         default: return "unknown"
         }
     }
-    
+
     class func mapFromChargeStatus(_ status: ChargeStatus) -> String {
         switch status {
         case ChargeStatus.failed: return "failed"
@@ -299,7 +299,7 @@ class Mappers {
         default: return "unknown"
         }
     }
-    
+
     class func mapFromReaderDisplayMessage(_ displayMessage: ReaderDisplayMessage) -> String {
         switch displayMessage {
         case ReaderDisplayMessage.insertCard: return "insertCard"
@@ -314,11 +314,11 @@ class Mappers {
         default: return "unknown"
         }
     }
-    
+
     class func mapFromReaderInputOptions(_ inputOptions: ReaderInputOptions) -> NSMutableArray {
         let array = inputOptions.rawValue.bitComponents()
         let mappedOptions: NSMutableArray = []
-        
+
         array.forEach { item in
             switch item {
             case 0: return
@@ -328,21 +328,21 @@ class Mappers {
             default: return
             }
         }
-        
+
         return mappedOptions
     }
-    
+
     class func mapFromCharges(_ charges: [Charge]) -> [NSDictionary] {
         var list: [NSDictionary] = []
-        
+
         for charge in charges {
             let result = mapFromCharge(charge)
             list.append(result)
         }
-        
+
         return list
     }
-    
+
     class func mapFromReaderSoftwareUpdate(_ update: ReaderSoftwareUpdate?) -> [AnyHashable:Any?]? {
         guard let unwrappedUpdate = update else {
             return nil
@@ -354,7 +354,7 @@ class Mappers {
         ]
         return result
     }
-    
+
     class func mapFromUpdateTimeEstimate(_ time: UpdateTimeEstimate) -> String {
         switch time {
         case UpdateTimeEstimate.estimate1To2Minutes: return "estimate1To2Minutes"
@@ -364,21 +364,21 @@ class Mappers {
         default: return "unknown"
         }
     }
-    
-    
+
+
     class func mapFromLocationsList(_ locations: [Location]) -> [NSDictionary] {
         var list: [NSDictionary] = []
-        
+
         for location in locations {
             let result = mapFromLocation(location)
             if let result = result {
                 list.append(result)
             }
         }
-        
+
         return list
     }
-    
+
     class func mapFromLocation(_ location: Location?) -> NSDictionary? {
         guard let unwrappedLocation = location else {
             return nil
@@ -391,7 +391,7 @@ class Mappers {
         ]
         return result
     }
-    
+
     class func mapFromAddress(_ address: Address?) -> NSDictionary? {
         if let address = address {
             let result: NSDictionary = [
@@ -407,13 +407,13 @@ class Mappers {
             return nil
         }
     }
-    
+
     class func mapFromCharge(_ charge: Charge) -> NSDictionary {
         var paymentMethodDetailsMap: NSDictionary?
         if let paymentMethodDetails = charge.paymentMethodDetails {
             paymentMethodDetailsMap = mapFromPaymentMethodDetails(paymentMethodDetails)
         }
-        
+
         let result: NSDictionary = [
             "amount": charge.amount,
             "description": charge.stripeDescription ?? NSNull(),
@@ -425,7 +425,7 @@ class Mappers {
         ]
         return result
     }
-    
+
     class func convertDateToUnixTimestamp(date: Date?) -> String? {
         if let date = date {
             let value = date.timeIntervalSince1970 * 1000.0
@@ -433,7 +433,7 @@ class Mappers {
         }
         return nil
     }
-    
+
     class func mapToSimulateReaderUpdate(_ update: String) -> SimulateReaderUpdate {
         switch update {
         case "available": return SimulateReaderUpdate.available
@@ -444,7 +444,7 @@ class Mappers {
         default: return SimulateReaderUpdate.none
         }
     }
-    
+
     class func mapFromCardPresent(_ cardPresent: CardPresentDetails) -> NSDictionary {
         var receiptDetailsMap: NSDictionary?
         if let receiptDetails = cardPresent.receipt {
@@ -474,46 +474,46 @@ class Mappers {
         ]
         return result
     }
-    
+
     class func mapFromOfflineDetails(_ offlineDetails: OfflineDetails) -> NSDictionary {
         var offlineCardPresentDetails: NSDictionary?
         if let cardPresentDetails = offlineDetails.cardPresentDetails {
             offlineCardPresentDetails = mapFromOfflineCardPresentDetails(cardPresentDetails)
         }
-        
+
         var amountDetails: NSDictionary?
         if let offlineAmountDetails = offlineDetails.amountDetails {
             amountDetails = mapFromAmountDetails(offlineAmountDetails)
         }
-        
+
         let result: NSDictionary = [
             "storedAt": convertDateToUnixTimestamp(date: offlineDetails.collectedAt) ?? NSNull(),
             "requiresUpload": offlineDetails.requiresUpload,
             "cardPresentDetails": offlineCardPresentDetails ?? NSNull(),
             "amountDetails": amountDetails ?? NSNull()
         ]
-        
+
         return result
     }
-    
+
     class func mapFromAmountDetails(_ amountDetails: SCPAmountDetails?) -> NSDictionary {
         let amount: NSDictionary = [
             "amount": amountDetails?.tip ?? NSNull(),
         ]
-        
+
         let result: NSDictionary = [
             "tip": amount
         ]
-        
+
         return result
     }
-    
+
     class func mapFromOfflineCardPresentDetails(_ offlineCardPresentDetails: OfflineCardPresentDetails) -> NSDictionary {
         var receiptDetailsMap: NSDictionary?
         if let receiptDetails = offlineCardPresentDetails.receiptDetails {
             receiptDetailsMap = mapFromReceiptDetails(receiptDetails)
         }
-        
+
         let result: NSDictionary = [
             "brand": offlineCardPresentDetails.brand,
             "cardholderName": offlineCardPresentDetails.cardholderName ?? NSNull(),
@@ -523,17 +523,17 @@ class Mappers {
             "readMethod": mapFromReadMethod(offlineCardPresentDetails.readMethod),
             "receiptDetails": receiptDetailsMap ?? NSNull()
         ]
-        
+
         return result
     }
-    
+
     class func mapFromCardPresentDetailsWallet(_ wallet: SCPWallet) -> NSDictionary {
         let result: NSDictionary = [
             "type": wallet.type
         ]
         return result
     }
-    
+
     class func mapFromCardPresentDetailsFunding(_ type: CardFundingType) -> String {
         switch type {
         case CardFundingType.debit: return "debit"
@@ -542,7 +542,7 @@ class Mappers {
         default: return "other"
         }
     }
-    
+
     class func mapFromCardPresentDetailsBrand(_ type: CardBrand) -> String {
         switch type {
         case CardBrand.visa: return "visa"
@@ -557,7 +557,7 @@ class Mappers {
         default: return "unknown"
         }
     }
-    
+
     class func mapFromCardPresentDetailsNetwork(_ type: NSNumber) -> String {
         switch type {
         case 0: return "visa"
@@ -572,7 +572,7 @@ class Mappers {
         default: return "unknown"
         }
     }
-    
+
     class func mapFromReceiptDetails(_ receiptDetails: ReceiptDetails) -> NSDictionary {
         let result: NSDictionary = [
             "accountType": receiptDetails.accountType,
@@ -586,7 +586,7 @@ class Mappers {
         ]
         return result
     }
-    
+
     class func mapFromPaymentMethodDetailsType(_ type: PaymentMethodType) -> String {
         switch type {
         case PaymentMethodType.card: return "card"
@@ -595,7 +595,7 @@ class Mappers {
         default: return "unknown"
         }
     }
-    
+
     class func mapFromPaymentMethodDetails(_ paymentMethodDetails: PaymentMethodDetails) -> NSDictionary {
         var cardPresentMapped: NSDictionary?
         if let cardPresent = paymentMethodDetails.cardPresent{
@@ -605,7 +605,7 @@ class Mappers {
         if let interacPresent = paymentMethodDetails.interacPresent{
             interacPresentMapped = mapFromCardPresent(interacPresent)
         }
-        
+
         let result: NSDictionary = [
             "type": mapFromPaymentMethodDetailsType(paymentMethodDetails.type),
             "cardPresentDetails": cardPresentMapped ?? NSNull(),
@@ -613,7 +613,7 @@ class Mappers {
         ]
         return result
     }
-    
+
     class func mapFromRefund(_ refund: Refund) -> NSDictionary {
         var paymentMethodDetailsMapped: NSDictionary?
         if let paymentMethodDetails = refund.paymentMethodDetails{
@@ -634,7 +634,7 @@ class Mappers {
         ]
         return result
     }
-    
+
     class func mapFromRefundStatus(_ type: RefundStatus) -> String {
         switch type {
         case RefundStatus.failed: return "failed"
@@ -644,7 +644,7 @@ class Mappers {
         default: return "unknown"
         }
     }
-    
+
     class func mapFromCardDetails(_ cardDetails: CardDetails) -> NSDictionary {
         let result: NSDictionary = [
             "brand": cardDetails.brand,
@@ -656,7 +656,7 @@ class Mappers {
         ]
         return result
     }
-    
+
     class func mapFromPaymentMethod(_ paymentMethod: PaymentMethod) -> NSDictionary {
         var cardPresentMapped: NSDictionary?
         if let cardPresent = paymentMethod.cardPresent{
@@ -666,7 +666,7 @@ class Mappers {
         if let interacPresent = paymentMethod.interacPresent{
             interacPresentMapped = mapFromCardPresent(interacPresent)
         }
-        
+
         let result: NSDictionary = [
             "cardPresentDetails": cardPresentMapped ?? NSNull(),
             "interacPresentDetails": interacPresentMapped ?? NSNull(),
@@ -674,7 +674,7 @@ class Mappers {
         ]
         return result
     }
-    
+
     class func mapFromPaymentStatus(_ paymentStatus: PaymentStatus) -> String {
         switch paymentStatus {
         case PaymentStatus.notReady: return "notReady"
@@ -684,7 +684,7 @@ class Mappers {
         default: return "unknown"
         }
     }
-    
+
     class func mapFromConnectionStatus(_ connectionStatus: ConnectionStatus) -> String {
         switch connectionStatus {
         case ConnectionStatus.connected: return "connected"
@@ -693,7 +693,7 @@ class Mappers {
         default: return "unknown"
         }
     }
-    
+
     class func mapToLogLevel(_ logLevel: String?) -> LogLevel {
         switch logLevel {
         case "none": return LogLevel.none
@@ -701,7 +701,7 @@ class Mappers {
         default: return LogLevel.none
         }
     }
-    
+
     class func mapFromNetworkStatus(_ status: NetworkStatus) -> String {
         switch status {
         case NetworkStatus.online: return "online"
@@ -710,14 +710,14 @@ class Mappers {
         default: return "unknown"
         }
     }
-    
+
     class func mapFromOfflineStatus(_ offlineStatus: OfflineStatus) -> NSDictionary {
         let sdkDict: NSDictionary = [
             "networkStatus": Mappers.mapFromNetworkStatus(offlineStatus.sdk.networkStatus),
             "offlinePaymentsCount": offlineStatus.sdk.paymentsCount ?? 0,
             "offlinePaymentAmountsByCurrency": offlineStatus.sdk.paymentAmountsByCurrency
         ]
-        
+
         var readerDict: NSDictionary = [:]
         if let reader = offlineStatus.reader {
             readerDict = [
@@ -726,10 +726,10 @@ class Mappers {
                 "offlinePaymentAmountsByCurrency": reader.paymentAmountsByCurrency
             ]
         }
-        
+
         return(["sdk": sdkDict, "reader": readerDict])
     }
-    
+
     class func mapFromReaderTextToSpeechStatus(_ status: ReaderTextToSpeechStatus) -> String {
         switch status {
         case ReaderTextToSpeechStatus.off: return "off"
@@ -738,12 +738,12 @@ class Mappers {
         default: return "unknown"
         }
     }
-    
+
     class func mapFromReaderSettings(_ readerSettings: ReaderSettings) -> NSDictionary {
         var accessibility: [String : Any] = [
             "textToSpeechStatus": mapFromReaderTextToSpeechStatus(readerSettings.accessibility.textToSpeechStatus),
         ]
-        
+
         let errorDic: NSDictionary
         if let error = readerSettings.accessibility.error as NSError? {
             errorDic = [
@@ -752,10 +752,10 @@ class Mappers {
             ]
             accessibility["error"] = errorDic
         }
-        
+
         return(["accessibility": accessibility])
     }
-    
+
     class func mapFromReaderDisconnectReason(_ reason: DisconnectReason) -> String {
         switch reason {
         case DisconnectReason.disconnectRequested: return "disconnectRequested"
@@ -767,7 +767,7 @@ class Mappers {
         default: return "unknown"
         }
     }
-    
+
     class func mapFromReadMethod(_ readMethod: SCPReadMethod) -> String {
         switch readMethod {
         case SCPReadMethod.contactEMV: return "contactEMV"
@@ -778,7 +778,7 @@ class Mappers {
         default: return "unknown"
         }
     }
-    
+
     class func mapFromToggleResult(_ toggleResult: NSNumber) -> String {
         switch toggleResult {
         case 0: return "ENABLED"
@@ -787,18 +787,18 @@ class Mappers {
         default: return "UNKNOWN"
         }
     }
-    
+
     class func mapFromToggleResultList(_ toggles: [NSNumber]) -> [String] {
         var list: [String] = []
-        
+
         for toggle in toggles {
             let result = mapFromToggleResult(toggle)
             list.append(result)
         }
-        
+
         return list
     }
-    
+
     class func mapFromCollectInputs(_ results: [CollectInputsResult]) -> NSDictionary {
         var collectInputResults: [String : Any] = [:]
         for result in results {
@@ -828,7 +828,7 @@ class Mappers {
                 collectInputResults["selectionResult"] = selectionResult
             }
         }
-        
+
         return (["collectInputResults": collectInputResults])
     }
 }
@@ -837,7 +837,7 @@ extension UInt {
     init(bitComponents : [UInt]) {
         self = bitComponents.reduce(0, +)
     }
-    
+
     func bitComponents() -> [UInt] {
         return (0 ..< 8*MemoryLayout<UInt>.size).map( { 1 << $0 }).filter( { self & $0 != 0 } )
     }

--- a/ios/Mappers.swift
+++ b/ios/Mappers.swift
@@ -658,12 +658,19 @@ class Mappers {
     }
 
     class func mapFromPaymentMethod(_ paymentMethod: PaymentMethod) -> NSDictionary {
+        var cardPresentMapped: NSDictionary?
+        if let cardPresent = paymentMethod.cardPresent{
+            cardPresentMapped = mapFromCardPresent(cardPresent)
+        }
+        var interacPresentMapped: NSDictionary?
+        if let interacPresent = paymentMethod.interacPresent{
+            interacPresentMapped = mapFromCardPresent(interacPresent)
+        }
+
         let result: NSDictionary = [
-            "id": paymentMethod.stripeId,
-            "created": convertDateToUnixTimestamp(date: paymentMethod.created) ?? NSNull(),
-            "customer": paymentMethod.customer ?? NSNull(),
-            "cardDetails": mapFromCardDetails(paymentMethod.card!),
             "type": mapFromPaymentMethodDetailsType(paymentMethod.type),
+            "cardPresentDetails": cardPresentMapped ?? NSNull(),
+            "interacPresentDetails": interacPresentMapped ?? NSNull(),
         ]
         return result
     }

--- a/ios/Mappers.swift
+++ b/ios/Mappers.swift
@@ -668,9 +668,9 @@ class Mappers {
         }
         
         let result: NSDictionary = [
-            "type": mapFromPaymentMethodDetailsType(paymentMethod.type),
             "cardPresentDetails": cardPresentMapped ?? NSNull(),
             "interacPresentDetails": interacPresentMapped ?? NSNull(),
+            "customer": paymentMethod.customer ?? NSNull()
         ]
         return result
     }

--- a/ios/Mappers.swift
+++ b/ios/Mappers.swift
@@ -3,15 +3,15 @@ import StripeTerminal
 class Mappers {
     class func mapFromReaders(_ readers: [Reader]) -> [NSDictionary] {
         var readersList: [NSDictionary] = []
-
+        
         for reader in readers {
             let result = mapFromReader(reader)
             readersList.append(result)
         }
-
+        
         return readersList
     }
-
+    
     class func mapFromReader(_ reader: Reader) -> NSDictionary {
         let result: NSDictionary = [
             "label": reader.label ?? NSNull(),
@@ -32,7 +32,7 @@ class Mappers {
         ]
         return result
     }
-
+    
     class func mapFromLocationStatus(_ status: LocationStatus) -> String {
         switch status {
         case LocationStatus.notSet: return "notSet"
@@ -41,7 +41,7 @@ class Mappers {
         default: return "unknown"
         }
     }
-
+    
     class func mapFromReaderNetworkStatus(_ status: ReaderNetworkStatus) -> String {
         switch status {
         case ReaderNetworkStatus.offline: return "offline"
@@ -49,7 +49,7 @@ class Mappers {
         default: return "unknown"
         }
     }
-
+    
     class func mapFromBatteryStatus(_ status: BatteryStatus) -> String {
         switch status {
         case BatteryStatus.critical: return "critical"
@@ -59,7 +59,7 @@ class Mappers {
         default: return "unknown"
         }
     }
-
+    
     class func mapFromDeviceType(_ type: DeviceType) -> String {
         switch type {
         case DeviceType.appleBuiltIn: return "appleBuiltIn"
@@ -95,12 +95,12 @@ class Mappers {
         default: return nil
         }
     }
-
+    
     class func mapToCartLineItem(_ cartLineItem: NSDictionary) -> CartLineItem? {
         guard let displayName = cartLineItem["displayName"] as? String else { return nil }
         guard let quantity = cartLineItem["quantity"] as? NSNumber else { return nil }
         guard let amount = cartLineItem["amount"] as? NSNumber else { return nil }
-
+        
         do {
             let lineItem = try CartLineItemBuilder(displayName: displayName)
                 .setQuantity(Int(truncating: quantity))
@@ -112,10 +112,10 @@ class Mappers {
             return nil
         }
     }
-
+    
     class func mapToCartLineItems(_ cartLineItems: NSArray) -> [CartLineItem] {
         var items = [CartLineItem]()
-
+        
         cartLineItems.forEach {
             if let item = $0 as? NSDictionary {
                 if let lineItem = Mappers.mapToCartLineItem(item) {
@@ -125,8 +125,8 @@ class Mappers {
         }
         return items
     }
-
-
+    
+    
     class func mapToDiscoveryMethod(_ discoveryMethod: String?) -> DiscoveryMethod {
         if let method = discoveryMethod {
             switch method {
@@ -139,7 +139,7 @@ class Mappers {
         }
         return DiscoveryMethod.internet
     }
-
+    
     class func mapToDiscoveryConfiguration(_ discoveryMethod: String?, simulated: Bool, timeout: UInt) throws-> DiscoveryConfiguration {
         switch discoveryMethod {
         case "bluetoothScan":
@@ -163,7 +163,7 @@ class Mappers {
         default: return "unknown"
         }
     }
-
+    
     class func mapFromPaymentIntent(_ paymentIntent: PaymentIntent, uuid: String) -> NSDictionary {
         var offlineDetailsMap: NSDictionary?
         if let offlineDetails = paymentIntent.offlineDetails {
@@ -197,7 +197,7 @@ class Mappers {
         ]
         return result
     }
-
+    
     class func mapFromSetupIntent(_ setupIntent: SetupIntent, uuid: String) -> NSDictionary {
         var metadataMap: NSDictionary?
         if let metadata = setupIntent.metadata {
@@ -216,7 +216,7 @@ class Mappers {
         ]
         return result
     }
-
+    
     class func mapFromSetupIntentUsage(_ usage: SetupIntentUsage) -> String {
         switch usage {
         case SetupIntentUsage.offSession: return "offSession"
@@ -224,7 +224,7 @@ class Mappers {
         default: return "unknown"
         }
     }
-
+    
     class func mapFromSetupAttempt(_ attempt: SetupAttempt?) -> NSDictionary? {
         guard let unwrappedAttempt = attempt else {
             return nil
@@ -242,7 +242,7 @@ class Mappers {
         ]
         return result
     }
-
+    
     class func mapFromSetupAttemptPaymentMethodDetails(_ details: SetupAttemptPaymentMethodDetails?) -> NSDictionary? {
         guard let unwrappedDetails = details else {
             return nil
@@ -254,7 +254,7 @@ class Mappers {
         ]
         return result
     }
-
+    
     class func mapFromSetupAttemptCardPresentDetails(_ details: SetupAttemptCardPresentDetails?) -> NSDictionary? {
         guard let unwrappedDetails = details else {
             return nil
@@ -265,8 +265,8 @@ class Mappers {
         ]
         return result
     }
-
-
+    
+    
     class func mapFromSetupIntentStatus(_ status: SetupIntentStatus) -> String {
         switch status {
         case SetupIntentStatus.canceled: return "canceled"
@@ -278,7 +278,7 @@ class Mappers {
         default: return "unknown"
         }
     }
-
+    
     class func mapFromPaymentIntentStatus(_ status: PaymentIntentStatus) -> String {
         switch status {
         case PaymentIntentStatus.canceled: return "canceled"
@@ -290,7 +290,7 @@ class Mappers {
         default: return "unknown"
         }
     }
-
+    
     class func mapFromChargeStatus(_ status: ChargeStatus) -> String {
         switch status {
         case ChargeStatus.failed: return "failed"
@@ -299,7 +299,7 @@ class Mappers {
         default: return "unknown"
         }
     }
-
+    
     class func mapFromReaderDisplayMessage(_ displayMessage: ReaderDisplayMessage) -> String {
         switch displayMessage {
         case ReaderDisplayMessage.insertCard: return "insertCard"
@@ -314,11 +314,11 @@ class Mappers {
         default: return "unknown"
         }
     }
-
+    
     class func mapFromReaderInputOptions(_ inputOptions: ReaderInputOptions) -> NSMutableArray {
         let array = inputOptions.rawValue.bitComponents()
         let mappedOptions: NSMutableArray = []
-
+        
         array.forEach { item in
             switch item {
             case 0: return
@@ -328,21 +328,21 @@ class Mappers {
             default: return
             }
         }
-
+        
         return mappedOptions
     }
-
+    
     class func mapFromCharges(_ charges: [Charge]) -> [NSDictionary] {
         var list: [NSDictionary] = []
-
+        
         for charge in charges {
             let result = mapFromCharge(charge)
             list.append(result)
         }
-
+        
         return list
     }
-
+    
     class func mapFromReaderSoftwareUpdate(_ update: ReaderSoftwareUpdate?) -> [AnyHashable:Any?]? {
         guard let unwrappedUpdate = update else {
             return nil
@@ -354,7 +354,7 @@ class Mappers {
         ]
         return result
     }
-
+    
     class func mapFromUpdateTimeEstimate(_ time: UpdateTimeEstimate) -> String {
         switch time {
         case UpdateTimeEstimate.estimate1To2Minutes: return "estimate1To2Minutes"
@@ -364,21 +364,21 @@ class Mappers {
         default: return "unknown"
         }
     }
-
-
+    
+    
     class func mapFromLocationsList(_ locations: [Location]) -> [NSDictionary] {
         var list: [NSDictionary] = []
-
+        
         for location in locations {
             let result = mapFromLocation(location)
             if let result = result {
                 list.append(result)
             }
         }
-
+        
         return list
     }
-
+    
     class func mapFromLocation(_ location: Location?) -> NSDictionary? {
         guard let unwrappedLocation = location else {
             return nil
@@ -391,7 +391,7 @@ class Mappers {
         ]
         return result
     }
-
+    
     class func mapFromAddress(_ address: Address?) -> NSDictionary? {
         if let address = address {
             let result: NSDictionary = [
@@ -407,13 +407,13 @@ class Mappers {
             return nil
         }
     }
-
+    
     class func mapFromCharge(_ charge: Charge) -> NSDictionary {
         var paymentMethodDetailsMap: NSDictionary?
         if let paymentMethodDetails = charge.paymentMethodDetails {
             paymentMethodDetailsMap = mapFromPaymentMethodDetails(paymentMethodDetails)
         }
-
+        
         let result: NSDictionary = [
             "amount": charge.amount,
             "description": charge.stripeDescription ?? NSNull(),
@@ -425,7 +425,7 @@ class Mappers {
         ]
         return result
     }
-
+    
     class func convertDateToUnixTimestamp(date: Date?) -> String? {
         if let date = date {
             let value = date.timeIntervalSince1970 * 1000.0
@@ -433,7 +433,7 @@ class Mappers {
         }
         return nil
     }
-
+    
     class func mapToSimulateReaderUpdate(_ update: String) -> SimulateReaderUpdate {
         switch update {
         case "available": return SimulateReaderUpdate.available
@@ -444,7 +444,7 @@ class Mappers {
         default: return SimulateReaderUpdate.none
         }
     }
-
+    
     class func mapFromCardPresent(_ cardPresent: CardPresentDetails) -> NSDictionary {
         var receiptDetailsMap: NSDictionary?
         if let receiptDetails = cardPresent.receipt {
@@ -474,46 +474,46 @@ class Mappers {
         ]
         return result
     }
-
+    
     class func mapFromOfflineDetails(_ offlineDetails: OfflineDetails) -> NSDictionary {
         var offlineCardPresentDetails: NSDictionary?
         if let cardPresentDetails = offlineDetails.cardPresentDetails {
             offlineCardPresentDetails = mapFromOfflineCardPresentDetails(cardPresentDetails)
         }
-
+        
         var amountDetails: NSDictionary?
         if let offlineAmountDetails = offlineDetails.amountDetails {
             amountDetails = mapFromAmountDetails(offlineAmountDetails)
         }
-
+        
         let result: NSDictionary = [
             "storedAt": convertDateToUnixTimestamp(date: offlineDetails.collectedAt) ?? NSNull(),
             "requiresUpload": offlineDetails.requiresUpload,
             "cardPresentDetails": offlineCardPresentDetails ?? NSNull(),
             "amountDetails": amountDetails ?? NSNull()
         ]
-
+        
         return result
     }
-
+    
     class func mapFromAmountDetails(_ amountDetails: SCPAmountDetails?) -> NSDictionary {
         let amount: NSDictionary = [
             "amount": amountDetails?.tip ?? NSNull(),
         ]
-
+        
         let result: NSDictionary = [
             "tip": amount
         ]
-
+        
         return result
     }
-
+    
     class func mapFromOfflineCardPresentDetails(_ offlineCardPresentDetails: OfflineCardPresentDetails) -> NSDictionary {
         var receiptDetailsMap: NSDictionary?
         if let receiptDetails = offlineCardPresentDetails.receiptDetails {
             receiptDetailsMap = mapFromReceiptDetails(receiptDetails)
         }
-
+        
         let result: NSDictionary = [
             "brand": offlineCardPresentDetails.brand,
             "cardholderName": offlineCardPresentDetails.cardholderName ?? NSNull(),
@@ -523,17 +523,17 @@ class Mappers {
             "readMethod": mapFromReadMethod(offlineCardPresentDetails.readMethod),
             "receiptDetails": receiptDetailsMap ?? NSNull()
         ]
-
+        
         return result
     }
-
+    
     class func mapFromCardPresentDetailsWallet(_ wallet: SCPWallet) -> NSDictionary {
         let result: NSDictionary = [
             "type": wallet.type
         ]
         return result
     }
-
+    
     class func mapFromCardPresentDetailsFunding(_ type: CardFundingType) -> String {
         switch type {
         case CardFundingType.debit: return "debit"
@@ -542,7 +542,7 @@ class Mappers {
         default: return "other"
         }
     }
-
+    
     class func mapFromCardPresentDetailsBrand(_ type: CardBrand) -> String {
         switch type {
         case CardBrand.visa: return "visa"
@@ -557,7 +557,7 @@ class Mappers {
         default: return "unknown"
         }
     }
-
+    
     class func mapFromCardPresentDetailsNetwork(_ type: NSNumber) -> String {
         switch type {
         case 0: return "visa"
@@ -572,7 +572,7 @@ class Mappers {
         default: return "unknown"
         }
     }
-
+    
     class func mapFromReceiptDetails(_ receiptDetails: ReceiptDetails) -> NSDictionary {
         let result: NSDictionary = [
             "accountType": receiptDetails.accountType,
@@ -586,7 +586,7 @@ class Mappers {
         ]
         return result
     }
-
+    
     class func mapFromPaymentMethodDetailsType(_ type: PaymentMethodType) -> String {
         switch type {
         case PaymentMethodType.card: return "card"
@@ -595,7 +595,7 @@ class Mappers {
         default: return "unknown"
         }
     }
-
+    
     class func mapFromPaymentMethodDetails(_ paymentMethodDetails: PaymentMethodDetails) -> NSDictionary {
         var cardPresentMapped: NSDictionary?
         if let cardPresent = paymentMethodDetails.cardPresent{
@@ -605,7 +605,7 @@ class Mappers {
         if let interacPresent = paymentMethodDetails.interacPresent{
             interacPresentMapped = mapFromCardPresent(interacPresent)
         }
-
+        
         let result: NSDictionary = [
             "type": mapFromPaymentMethodDetailsType(paymentMethodDetails.type),
             "cardPresentDetails": cardPresentMapped ?? NSNull(),
@@ -613,7 +613,7 @@ class Mappers {
         ]
         return result
     }
-
+    
     class func mapFromRefund(_ refund: Refund) -> NSDictionary {
         var paymentMethodDetailsMapped: NSDictionary?
         if let paymentMethodDetails = refund.paymentMethodDetails{
@@ -634,7 +634,7 @@ class Mappers {
         ]
         return result
     }
-
+    
     class func mapFromRefundStatus(_ type: RefundStatus) -> String {
         switch type {
         case RefundStatus.failed: return "failed"
@@ -644,7 +644,7 @@ class Mappers {
         default: return "unknown"
         }
     }
-
+    
     class func mapFromCardDetails(_ cardDetails: CardDetails) -> NSDictionary {
         let result: NSDictionary = [
             "brand": cardDetails.brand,
@@ -656,7 +656,7 @@ class Mappers {
         ]
         return result
     }
-
+    
     class func mapFromPaymentMethod(_ paymentMethod: PaymentMethod) -> NSDictionary {
         var cardPresentMapped: NSDictionary?
         if let cardPresent = paymentMethod.cardPresent{
@@ -666,7 +666,7 @@ class Mappers {
         if let interacPresent = paymentMethod.interacPresent{
             interacPresentMapped = mapFromCardPresent(interacPresent)
         }
-
+        
         let result: NSDictionary = [
             "type": mapFromPaymentMethodDetailsType(paymentMethod.type),
             "cardPresentDetails": cardPresentMapped ?? NSNull(),
@@ -674,7 +674,7 @@ class Mappers {
         ]
         return result
     }
-
+    
     class func mapFromPaymentStatus(_ paymentStatus: PaymentStatus) -> String {
         switch paymentStatus {
         case PaymentStatus.notReady: return "notReady"
@@ -684,7 +684,7 @@ class Mappers {
         default: return "unknown"
         }
     }
-
+    
     class func mapFromConnectionStatus(_ connectionStatus: ConnectionStatus) -> String {
         switch connectionStatus {
         case ConnectionStatus.connected: return "connected"
@@ -693,7 +693,7 @@ class Mappers {
         default: return "unknown"
         }
     }
-
+    
     class func mapToLogLevel(_ logLevel: String?) -> LogLevel {
         switch logLevel {
         case "none": return LogLevel.none
@@ -701,7 +701,7 @@ class Mappers {
         default: return LogLevel.none
         }
     }
-
+    
     class func mapFromNetworkStatus(_ status: NetworkStatus) -> String {
         switch status {
         case NetworkStatus.online: return "online"
@@ -710,14 +710,14 @@ class Mappers {
         default: return "unknown"
         }
     }
-
+    
     class func mapFromOfflineStatus(_ offlineStatus: OfflineStatus) -> NSDictionary {
         let sdkDict: NSDictionary = [
             "networkStatus": Mappers.mapFromNetworkStatus(offlineStatus.sdk.networkStatus),
             "offlinePaymentsCount": offlineStatus.sdk.paymentsCount ?? 0,
             "offlinePaymentAmountsByCurrency": offlineStatus.sdk.paymentAmountsByCurrency
         ]
-
+        
         var readerDict: NSDictionary = [:]
         if let reader = offlineStatus.reader {
             readerDict = [
@@ -726,10 +726,10 @@ class Mappers {
                 "offlinePaymentAmountsByCurrency": reader.paymentAmountsByCurrency
             ]
         }
-
+        
         return(["sdk": sdkDict, "reader": readerDict])
     }
-
+    
     class func mapFromReaderTextToSpeechStatus(_ status: ReaderTextToSpeechStatus) -> String {
         switch status {
         case ReaderTextToSpeechStatus.off: return "off"
@@ -738,12 +738,12 @@ class Mappers {
         default: return "unknown"
         }
     }
-
+    
     class func mapFromReaderSettings(_ readerSettings: ReaderSettings) -> NSDictionary {
         var accessibility: [String : Any] = [
             "textToSpeechStatus": mapFromReaderTextToSpeechStatus(readerSettings.accessibility.textToSpeechStatus),
         ]
-
+        
         let errorDic: NSDictionary
         if let error = readerSettings.accessibility.error as NSError? {
             errorDic = [
@@ -752,10 +752,10 @@ class Mappers {
             ]
             accessibility["error"] = errorDic
         }
-
+        
         return(["accessibility": accessibility])
     }
-
+    
     class func mapFromReaderDisconnectReason(_ reason: DisconnectReason) -> String {
         switch reason {
         case DisconnectReason.disconnectRequested: return "disconnectRequested"
@@ -767,7 +767,7 @@ class Mappers {
         default: return "unknown"
         }
     }
-
+    
     class func mapFromReadMethod(_ readMethod: SCPReadMethod) -> String {
         switch readMethod {
         case SCPReadMethod.contactEMV: return "contactEMV"
@@ -790,15 +790,15 @@ class Mappers {
     
     class func mapFromToggleResultList(_ toggles: [NSNumber]) -> [String] {
         var list: [String] = []
-
+        
         for toggle in toggles {
             let result = mapFromToggleResult(toggle)
             list.append(result)
         }
-
+        
         return list
     }
-
+    
     class func mapFromCollectInputs(_ results: [CollectInputsResult]) -> NSDictionary {
         var collectInputResults: [String : Any] = [:]
         for result in results {
@@ -828,7 +828,7 @@ class Mappers {
                 collectInputResults["selectionResult"] = selectionResult
             }
         }
-
+        
         return (["collectInputResults": collectInputResults])
     }
 }
@@ -837,7 +837,7 @@ extension UInt {
     init(bitComponents : [UInt]) {
         self = bitComponents.reduce(0, +)
     }
-
+    
     func bitComponents() -> [UInt] {
         return (0 ..< 8*MemoryLayout<UInt>.size).map( { 1 << $0 }).filter( { self & $0 != 0 } )
     }

--- a/ios/Mappers.swift
+++ b/ios/Mappers.swift
@@ -670,7 +670,9 @@ class Mappers {
         let result: NSDictionary = [
             "cardPresentDetails": cardPresentMapped ?? NSNull(),
             "interacPresentDetails": interacPresentMapped ?? NSNull(),
-            "customer": paymentMethod.customer ?? NSNull()
+            "customer": paymentMethod.customer ?? NSNull(),
+            "id": paymentMethod.stripeId,
+            "metadata": NSDictionary(dictionary: paymentMethod.metadata),
         ]
         return result
     }


### PR DESCRIPTION
## Summary
Our current paymentMethod mapper maps the `paymentMethod.card` field instead of `paymentMethod.cardPresent`. This PR adds support for mapping card and interac present
<!-- Simple summary of what was changed. -->

## Motivation
https://github.com/stripe/stripe-terminal-react-native/issues/697
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
