### PR TITLE
Nullify collect cancelables after confirm

### DIFF
--- a/ios/StripeTerminalReactNative.swift
+++ b/ios/StripeTerminalReactNative.swift
@@ -555,7 +555,6 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, BluetoothRe
                 let paymentIntent = Mappers.mapFromPaymentIntent(paymentIntent, uuid: uuid)
                 resolve(["paymentIntent": paymentIntent])
             }
-            self.collectPaymentMethodCancelable = nil
         }
     }
 
@@ -635,6 +634,7 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, BluetoothRe
                 resolve(["paymentIntent": paymentIntent])
             }
         }
+        self.collectPaymentMethodCancelable = nil
     }
 
     func terminal(_ terminal: Terminal, didChangePaymentStatus status: PaymentStatus) {
@@ -836,7 +836,6 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, BluetoothRe
                 let setupIntent = Mappers.mapFromSetupIntent(setupIntent, uuid: uuid)
                 resolve(["setupIntent": setupIntent])
             }
-            self.collectSetupIntentCancelable = nil
         }
     }
 
@@ -861,6 +860,7 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, BluetoothRe
                 resolve(["setupIntent": setupIntent])
             }
         }
+        self.collectRefundPaymentMethodCancelable = nil
     }
 
     @objc(collectRefundPaymentMethod:resolver:rejecter:)
@@ -917,7 +917,6 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, BluetoothRe
             } else {
                 resolve([:])
             }
-            self.collectRefundPaymentMethodCancelable = nil
         }
     }
 
@@ -931,6 +930,7 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, BluetoothRe
                 resolve(["refund": refund])
             }
         }
+        self.collectRefundPaymentMethodCancelable = nil
     }
 
     @objc(clearCachedCredentials:rejecter:)


### PR DESCRIPTION
## Summary
For iOS reset all cancelables after confirm calls succeed.
<!-- Simple summary of what was changed. -->

## Motivation

<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->
Currently we set cancelables to nil after collect confirms, which causes issues when trying to inspect PM and decline payments between collect and confirm.

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
