### PR TITLE
Fixed the amount mismatch in full refund

### DIFF
--- a/dev-app/src/AppContext.ts
+++ b/dev-app/src/AppContext.ts
@@ -13,6 +13,8 @@ export const AppContext = React.createContext<IAppContext>({
   setLastSuccessfulChargeId: (_id) => null,
   lastSuccessfulPaymentIntentId: null,
   setLastSuccessfulPaymentIntentId: (_id) => null,
+  lastSuccessfulAmount: null,
+  setLastSuccessfulAmount: (_a) => null,
   autoReconnectOnUnexpectedDisconnect: false,
   setAutoReconnectOnUnexpectedDisconnect: (_b) => null,
   cachedLocations: [],

--- a/dev-app/src/Root.tsx
+++ b/dev-app/src/Root.tsx
@@ -21,6 +21,9 @@ export default function Root() {
   >(null);
   const [lastSuccessfulPaymentIntentId, setLastSuccessfulPaymentIntentId] =
     useState<string | null>(null);
+  const [lastSuccessfulAmount, setLastSuccessfulAmount] = useState<
+    string | null
+  >(null);
   const [
     autoReconnectOnUnexpectedDisconnect,
     setAutoReconnectOnUnexpectedDisconnect,
@@ -96,6 +99,8 @@ export default function Root() {
         setLastSuccessfulPaymentIntentId: (id) =>
           setLastSuccessfulPaymentIntentId(id),
         lastSuccessfulPaymentIntentId,
+        setLastSuccessfulAmount: (a) => setLastSuccessfulAmount(a),
+        lastSuccessfulAmount,
         autoReconnectOnUnexpectedDisconnect,
         setAutoReconnectOnUnexpectedDisconnect: (b) =>
           setAutoReconnectOnUnexpectedDisconnect(b),

--- a/dev-app/src/screens/CollectCardPaymentScreen.tsx
+++ b/dev-app/src/screens/CollectCardPaymentScreen.tsx
@@ -50,6 +50,7 @@ export default function CollectCardPaymentScreen() {
     api,
     setLastSuccessfulChargeId,
     setLastSuccessfulPaymentIntentId,
+    setLastSuccessfulAmount,
     account,
   } = useContext(AppContext);
 
@@ -426,6 +427,7 @@ export default function CollectCardPaymentScreen() {
     if (paymentIntent?.charges[0]?.id) {
       setLastSuccessfulChargeId(paymentIntent.charges[0].id);
       setLastSuccessfulPaymentIntentId(paymentIntent.id);
+      setLastSuccessfulAmount(paymentIntent.amount.toString());
     }
 
     if (paymentIntent?.status === 'succeeded') {

--- a/dev-app/src/screens/RefundPaymentScreen.tsx
+++ b/dev-app/src/screens/RefundPaymentScreen.tsx
@@ -21,8 +21,11 @@ import type { RouteParamList } from '../App';
 import { Picker } from '@react-native-picker/picker';
 
 export default function RefundPaymentScreen() {
-  const { lastSuccessfulChargeId, lastSuccessfulPaymentIntentId } =
-    useContext(AppContext);
+  const {
+    lastSuccessfulAmount,
+    lastSuccessfulChargeId,
+    lastSuccessfulPaymentIntentId,
+  } = useContext(AppContext);
   const [inputValues, setInputValues] = useState<{
     chargeId: string;
     paymentIntentId: string;
@@ -34,7 +37,7 @@ export default function RefundPaymentScreen() {
   }>({
     chargeId: lastSuccessfulChargeId || '',
     paymentIntentId: lastSuccessfulPaymentIntentId || '',
-    amount: '100',
+    amount: lastSuccessfulAmount || '',
     currency: 'CAD',
     refundApplicationFee: false,
     reverseTransfer: false,

--- a/dev-app/src/types.ts
+++ b/dev-app/src/types.ts
@@ -16,6 +16,8 @@ export type IAppContext = {
   setLastSuccessfulChargeId: (id: string) => void;
   lastSuccessfulPaymentIntentId: string | null;
   setLastSuccessfulPaymentIntentId: (id: string) => void;
+  lastSuccessfulAmount: string | null;
+  setLastSuccessfulAmount: (amount: string) => void;
   autoReconnectOnUnexpectedDisconnect: boolean | false;
   setAutoReconnectOnUnexpectedDisconnect: (b: boolean) => void;
   cachedLocations: Array<Location>;


### PR DESCRIPTION

## Summary

Fixed issue where  amount in full refund did not match the last payment on the React Native dev-app

## Motivation

Make sure app can detect the correct charge ID and last payment amount , so that user no need to input manually.

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
