### PR TITLE
Minor typo when reader is disconnected caught during QA

### DIFF
--- a/dev-app/src/screens/HomeScreen.tsx
+++ b/dev-app/src/screens/HomeScreen.tsx
@@ -91,7 +91,7 @@ export default function HomeScreen() {
       );
     },
     onDidStartReaderReconnect() {
-      Alert.alert('Reconnecting...', 'Reader has disconneted.', [
+      Alert.alert('Reconnecting...', 'Reader has disconnected.', [
         {
           text: 'Cancel',
           onPress: async () => {


### PR DESCRIPTION
## Summary

s/disconneted/disconnected

## Motivation

[https://jira.corp.stripe.com/browse/RUN_TERMINAL_SDK-820](https://jira.corp.stripe.com/browse/RUN_TERMINAL_SDK-820) [mPOS][RN] Bluetooth reconnection popup misspelled 'disconnect'

## Testing

- [ ] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [X] This PR does not result in any developer-facing changes.