### PR TITLE
CreatePaymentIntent improvements

### DIFF
--- a/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
@@ -372,12 +372,10 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
         val captureMethod = params.getString("captureMethod")
         val offlineBehavior = params.getString("offlineBehavior")
 
-        val paymentMethodTypes = paymentMethods?.toArrayList()?.mapNotNull {
-            if (it is String) {
-                PaymentMethodType.valueOf(it.uppercase())
-            } else {
-                null
-            }
+        val paymentMethodTypes = paymentMethods?.toArrayList()?.mapNotNull { 
+            it as? String 
+        }?.map{
+            PaymentMethodType.valueOf(it.uppercase())
         }
 
         val intentParams = paymentMethodTypes?.let {
@@ -451,14 +449,14 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
             }
         }
 
-        val offlineBehaviorParam = offlineBehavior.let {
+        val offlineBehaviorParam = offlineBehavior?.let {
             when (it) {
                 "prefer_online" -> OfflineBehavior.PREFER_ONLINE
                 "require_online" -> OfflineBehavior.REQUIRE_ONLINE
                 "force_offline" -> OfflineBehavior.FORCE_OFFLINE
                 else -> OfflineBehavior.PREFER_ONLINE
             }
-        }
+        } ?: OfflineBehavior.PREFER_ONLINE
 
         val uuid = UUID.randomUUID().toString()
 

--- a/ios/StripeTerminalReactNative.swift
+++ b/ios/StripeTerminalReactNative.swift
@@ -397,7 +397,6 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, BluetoothRe
         let captureMethod = params["captureMethod"] as? String
 
         let paymentParamsBuilder = PaymentIntentParametersBuilder(amount: UInt(truncating: amount),currency: currency)
-            .setPaymentMethodTypes(paymentMethodTypes)
             .setCaptureMethod(captureMethod == "automatic" ? .automatic : .manual)
             .setSetupFutureUsage(setupFutureUsage)
             .setOnBehalfOf(onBehalfOf)
@@ -410,6 +409,10 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, BluetoothRe
             .setCustomer(customer)
             .setTransferGroup(transferGroup)
             .setMetadata(metadata)
+        
+        if !paymentMethodTypes.isEmpty {
+            paymentParamsBuilder.setPaymentMethodTypes(paymentMethodTypes)
+        }
 
         let cardPresentParamsBuilder = CardPresentParametersBuilder()
             .setRequestExtendedAuthorization(extendedAuth)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -174,7 +174,7 @@ export type CreatePaymentIntentParams = CreatePaymentIntentIOSParams & {
   metadata?: Record<string, string>;
   paymentMethodOptions?: PaymentMethodOptions;
   captureMethod?: 'automatic' | 'manual';
-  offlineBehavior: 'prefer_online' | 'require_online' | 'force_offline';
+  offlineBehavior?: 'prefer_online' | 'require_online' | 'force_offline';
 };
 
 export type CreatePaymentIntentIOSParams = {


### PR DESCRIPTION
## Summary

Adjust ‘offlineBehavior’ type to be optional and improve ‘paymentMethodTypes’ handling to align with default behavior
## Motivation

Make `offlineBehavior` optional and update `paymentMethodTypes` handling to omit rather than set to null, ensuring default card_present PaymentIntent creation by the native SDK.

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
