### PR TITLE
Fix dev-app cache Stripe-Account header-issue

### DIFF
--- a/dev-app/src/App.tsx
+++ b/dev-app/src/App.tsx
@@ -125,7 +125,7 @@ export default function App() {
   const { initialize: initStripe, clearCachedCredentials } =
     useStripeTerminal();
   const { account } = useContext(AppContext);
-
+  const { refreshToken } = useContext(AppContext);
   useEffect(() => {
     const initAndClear = async () => {
       const { error, reader } = await initStripe();
@@ -150,7 +150,7 @@ export default function App() {
     if (account?.secretKey && hasPerms) {
       initAndClear();
     }
-  }, [account, initStripe, clearCachedCredentials, hasPerms]);
+  }, [account, initStripe, clearCachedCredentials, hasPerms, refreshToken]);
 
   const handlePermissionsSuccess = useCallback(async () => {
     setHasPerms(true);

--- a/dev-app/src/AppContext.ts
+++ b/dev-app/src/AppContext.ts
@@ -19,4 +19,6 @@ export const AppContext = React.createContext<IAppContext>({
   setAutoReconnectOnUnexpectedDisconnect: (_b) => null,
   cachedLocations: [],
   setCachedLocations: (_locations) => null,
+  refreshToken: false,
+  setRefreshToken: (_b) => null,
 });

--- a/dev-app/src/Root.tsx
+++ b/dev-app/src/Root.tsx
@@ -28,6 +28,7 @@ export default function Root() {
     autoReconnectOnUnexpectedDisconnect,
     setAutoReconnectOnUnexpectedDisconnect,
   ] = useState<boolean | false>(false);
+  const [refreshToken, setRefreshToken] = useState<boolean | false>(false);
 
   const [cachedLocations, setCachedLocations] = useState<Location[]>([]);
 
@@ -106,6 +107,8 @@ export default function Root() {
           setAutoReconnectOnUnexpectedDisconnect(b),
         cachedLocations,
         setCachedLocations: (locations) => setCachedLocations(locations),
+        refreshToken,
+        setRefreshToken: (b) => setRefreshToken(b),
       }}
     >
       <StripeTerminalProvider

--- a/dev-app/src/screens/MerchantSelectScreen.tsx
+++ b/dev-app/src/screens/MerchantSelectScreen.tsx
@@ -12,7 +12,7 @@ import { Picker } from '@react-native-picker/picker';
 import { colors } from '../colors';
 import List from '../components/List';
 import ListItem from '../components/ListItem';
-import { api, AppContext } from '../AppContext';
+import { AppContext } from '../AppContext';
 import { Api } from '../api/api';
 import type { IShortAccount } from '../types';
 import {
@@ -23,6 +23,7 @@ import {
 } from '../util/merchantStorage';
 
 export default function MerchantSelectScreen() {
+  const { refreshToken, setRefreshToken } = useContext(AppContext);
   const { account, setAccount } = useContext(AppContext);
   const [accounts, setAccounts] = useState<Array<IShortAccount>>([]);
   const [isAddPending, setIsAddPending] = useState<boolean>(false);
@@ -53,7 +54,6 @@ export default function MerchantSelectScreen() {
   useEffect(() => {
     getStoredConnectedAccountID().then((value) => {
       if (value) {
-        api.directChargeStripeAccountID = value;
         setConnectedStripeAccountID(value);
       }
     });
@@ -62,8 +62,12 @@ export default function MerchantSelectScreen() {
   // store connected stripe account id to storage
   const onConnectedAccountInputChange = (value: string) => {
     setConnectedStripeAccountID(value);
-    api.setStripeAccountID(value);
     setStoredConnectedAccountID(value);
+  };
+
+  // Set a flag to trigger the update token re-request when the connectedStripeAccount changes.
+  const onEndInputTextContentChange = () => {
+    setRefreshToken(!refreshToken);
   };
 
   const onSelectAccount = useCallback(
@@ -144,6 +148,7 @@ export default function MerchantSelectScreen() {
           onChangeText={onConnectedAccountInputChange}
           placeholder="Connected Stripe Account ID"
           editable={!isAddPending}
+          onEndEditing={onEndInputTextContentChange}
         />
       </List>
       <List bolded={false} topSpacing={false} title="Select Merchant">

--- a/dev-app/src/types.ts
+++ b/dev-app/src/types.ts
@@ -22,6 +22,8 @@ export type IAppContext = {
   setAutoReconnectOnUnexpectedDisconnect: (b: boolean) => void;
   cachedLocations: Array<Location>;
   setCachedLocations: (locations: Array<Location>) => void;
+  refreshToken: boolean;
+  setRefreshToken: (b: boolean) => void;
 };
 
 export type IShortAccount = {


### PR DESCRIPTION
## Summary

Fixed a caching issue in the RN dev app that led to the Stripe-Account header not being cleared between direct and destination charge attempts.

## Motivation

To ensure API calls are successful when switching between charge types, without the interference of erroneously cached account information.

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
