### PR TITLE
Fix incorrect unix time conversion at android layer

### DIFF
--- a/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
@@ -243,7 +243,7 @@ internal fun mapFromSetupIntent(setupIntent: SetupIntent, uuid: String): Readabl
 }
 
 internal fun mapFromSetupAttempt(attempt: SetupAttempt?): ReadableMap? = attempt?.let {
-    nativeMapOf {
+        nativeMapOf {
         putString("created", convertToUnixTimestamp(it.created))
         putString("id", it.id)
         putString("status", mapFromSetupAttemptStatus(it.status))
@@ -446,7 +446,7 @@ internal fun mapFromReaderSoftwareUpdate(update: ReaderSoftwareUpdate?): Writabl
                 "estimatedUpdateTime",
                 mapFromUpdateTimeEstimate(it.timeEstimate)
             )
-            putString("requiredAt", convertToUnixTimestamp(it.requiredAt.time))
+            putString("requiredAt", it.requiredAt.time.toString())
         }
     }
 

--- a/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
@@ -243,7 +243,7 @@ internal fun mapFromSetupIntent(setupIntent: SetupIntent, uuid: String): Readabl
 }
 
 internal fun mapFromSetupAttempt(attempt: SetupAttempt?): ReadableMap? = attempt?.let {
-        nativeMapOf {
+    nativeMapOf {
         putString("created", convertToUnixTimestamp(it.created))
         putString("id", it.id)
         putString("status", mapFromSetupAttemptStatus(it.status))


### PR DESCRIPTION
## Summary

Fix incorrect unix time conversion at Android layer.

## Motivation

User reported that The availableUpdate object on the connectedReader object returned by the hook useStripeTerminal is inconsistent between android and iOS (The android's requiredAt is 1000 times bigger than it should be). This PR aims to correct this discrepancy to ensure cross-platform functionality is consistent and accurate.
https://github.com/stripe/stripe-terminal-react-native/issues/718

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
