### PR TITLE
ConfirmPaymentIntent methods accept param objects

### DIFF
--- a/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
@@ -372,8 +372,8 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
         val captureMethod = params.getString("captureMethod")
         val offlineBehavior = params.getString("offlineBehavior")
 
-        val paymentMethodTypes = paymentMethods?.toArrayList()?.mapNotNull { 
-            it as? String 
+        val paymentMethodTypes = paymentMethods?.toArrayList()?.mapNotNull {
+            it as? String
         }?.map{
             PaymentMethodType.valueOf(it.uppercase())
         }
@@ -707,9 +707,12 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
 
     @ReactMethod
     @Suppress("unused")
-    fun confirmSetupIntent(setupIntent: ReadableMap, promise: Promise) =
+    fun confirmSetupIntent(params: ReadableMap, promise: Promise) =
         withExceptionResolver(promise) {
-            val uuid = requireParam(setupIntent.getString("sdkUuid")) {
+            val setupIntentJson = requireParam(params.getMap("setupIntent")) {
+                "You must provide a setupIntent."
+            }
+            val uuid = requireParam(setupIntentJson.getString("sdkUuid")) {
                 "The SetupIntent is missing sdkUuid field. This method requires you to use the SetupIntent that was returned from either createPaymentIntent or retrievePaymentIntent."
             }
             val setupIntent = requireParam(setupIntents[uuid]) {

--- a/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
@@ -598,9 +598,12 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
     @OptIn(OfflineMode::class)
     @ReactMethod
     @Suppress("unused")
-    fun cancelPaymentIntent(paymentIntent: ReadableMap, promise: Promise) =
+    fun cancelPaymentIntent(params: ReadableMap, promise: Promise) =
         withExceptionResolver(promise) {
-            val uuid = requireParam(paymentIntent.getString("sdkUuid")) {
+            val paymentIntentJson = requireParam(params.getMap("paymentIntent")) {
+                "You must provide paymentIntent that was returned from either createPaymentIntent or retrievePaymentIntent."
+            }
+            val uuid = requireParam(paymentIntentJson.getString("sdkUuid")) {
                 "The PaymentIntent is missing sdkUuid field. This method requires you to use the PaymentIntent that was returned from either createPaymentIntent or retrievePaymentIntent."
             }
             val paymentIntent = requireParam(paymentIntents[uuid]) {

--- a/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
@@ -685,9 +685,12 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
 
     @ReactMethod
     @Suppress("unused")
-    fun cancelSetupIntent(setupIntent: ReadableMap, promise: Promise) =
+    fun cancelSetupIntent(params: ReadableMap, promise: Promise) =
         withExceptionResolver(promise) {
-            val uuid = requireParam(setupIntent.getString("sdkUuid")) {
+            val setupIntentJson = requireParam(params.getMap("setupIntent")) {
+                "You must provide a setupIntent."
+            }
+            val uuid = requireParam(setupIntentJson.getString("sdkUuid")) {
                 "The SetupIntent is missing sdkUuid field. This method requires you to use the SetupIntent that was returned from either createPaymentIntent or retrievePaymentIntent."
             }
             val setupIntent = requireParam(setupIntents[uuid]) {

--- a/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
@@ -535,10 +535,13 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
 
     @ReactMethod
     @Suppress("unused")
-    fun confirmPaymentIntent(paymentIntent: ReadableMap, promise: Promise) = withExceptionResolver(
+    fun confirmPaymentIntent(params: ReadableMap, promise: Promise) = withExceptionResolver(
         promise
     ) {
-        val uuid = requireParam(paymentIntent.getString("sdkUuid")) {
+        val paymentIntentJson = requireParam(params.getMap("paymentIntent")) {
+            "You must provide a paymentIntent that was returned from either createPaymentIntent or retrievePaymentIntent."
+        }
+        val uuid = requireParam(paymentIntentJson.getString("sdkUuid")) {
             "The PaymentIntent is missing sdkUuid field. This method requires you to use the PaymentIntent that was returned from either createPaymentIntent or retrievePaymentIntent."
         }
         val paymentIntent = requireParam(paymentIntents[uuid]) {

--- a/dev-app/src/screens/CollectCardPaymentScreen.tsx
+++ b/dev-app/src/screens/CollectCardPaymentScreen.tsx
@@ -436,9 +436,9 @@ export default function CollectCardPaymentScreen() {
       ],
     });
 
-    const { paymentIntent, error } = await confirmPaymentIntent(
-      collectedPaymentIntent
-    );
+    const { paymentIntent, error } = await confirmPaymentIntent({
+      paymentIntent: collectedPaymentIntent,
+    });
 
     if (error) {
       addLogs({

--- a/dev-app/src/screens/SetupIntentScreen.tsx
+++ b/dev-app/src/screens/SetupIntentScreen.tsx
@@ -69,7 +69,9 @@ export default function SetupIntentScreen() {
           },
         ],
       });
-      const { setupIntent, error } = await confirmSetupIntent(si);
+      const { setupIntent, error } = await confirmSetupIntent({
+        setupIntent: si,
+      });
       if (error) {
         addLogs({
           name: 'Process Payment',

--- a/ios/StripeTerminalReactNative.m
+++ b/ios/StripeTerminalReactNative.m
@@ -79,7 +79,7 @@ RCT_EXTERN_METHOD(
                   )
 
 RCT_EXTERN_METHOD(
-                  confirmPaymentIntent:(NSDictionary *)paymentIntentJson
+                  confirmPaymentIntent:(NSDictionary *)params
                   resolver: (RCTPromiseResolveBlock)resolve
                   rejecter: (RCTPromiseRejectBlock)reject
                   )

--- a/ios/StripeTerminalReactNative.m
+++ b/ios/StripeTerminalReactNative.m
@@ -129,7 +129,7 @@ RCT_EXTERN_METHOD(
                   )
 
 RCT_EXTERN_METHOD(
-                  cancelSetupIntent:(NSDictionary *)setupIntentJson
+                  cancelSetupIntent:(NSDictionary *)params
                   resolver: (RCTPromiseResolveBlock)resolve
                   rejecter: (RCTPromiseRejectBlock)reject
                   )

--- a/ios/StripeTerminalReactNative.m
+++ b/ios/StripeTerminalReactNative.m
@@ -90,7 +90,7 @@ RCT_EXTERN_METHOD(
                   )
 
 RCT_EXTERN_METHOD(
-                  cancelPaymentIntent:(NSDictionary *)paymentIntentJson
+                  cancelPaymentIntent:(NSDictionary *)params
                   resolver: (RCTPromiseResolveBlock)resolve
                   rejecter: (RCTPromiseRejectBlock)reject
                   )

--- a/ios/StripeTerminalReactNative.m
+++ b/ios/StripeTerminalReactNative.m
@@ -141,7 +141,7 @@ RCT_EXTERN_METHOD(
                   )
 
 RCT_EXTERN_METHOD(
-                  confirmSetupIntent:(NSDictionary *)setupIntentJson
+                  confirmSetupIntent:(NSDictionary *)params
                   resolver: (RCTPromiseResolveBlock)resolve
                   rejecter: (RCTPromiseRejectBlock)reject
                   )

--- a/ios/StripeTerminalReactNative.swift
+++ b/ios/StripeTerminalReactNative.swift
@@ -700,7 +700,11 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, BluetoothRe
     }
 
     @objc(cancelPaymentIntent:resolver:rejecter:)
-    func cancelPaymentIntent(paymentIntentJson: NSDictionary, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+    func cancelPaymentIntent(params: NSDictionary, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+        guard let paymentIntentJson = params["paymentIntent"] as? NSDictionary else {
+            resolve(Errors.createError(code: CommonErrorType.InvalidRequiredParameter, message: "You must provide paymentIntent that was returned from either createPaymentIntent or retrievePaymentIntent."))
+            return
+        }
         guard let uuid = paymentIntentJson["sdkUuid"] as? String else {
             resolve(Errors.createError(code: CommonErrorType.InvalidRequiredParameter, message: "The PaymentIntent is missing sdkUuid field. This method requires you to use the PaymentIntent that was returned from either createPaymentIntent or retrievePaymentIntent."))
             return

--- a/ios/StripeTerminalReactNative.swift
+++ b/ios/StripeTerminalReactNative.swift
@@ -630,8 +630,12 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, BluetoothRe
     }
 
     @objc(confirmPaymentIntent:resolver:rejecter:)
-    func confirmPaymentIntent(paymentIntentJson: NSDictionary, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
-        guard let uuid = paymentIntentJson["sdkUuid"] as? String else {
+    func confirmPaymentIntent(params: NSDictionary, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+        guard let paymentIntentJSON = params["paymentIntent"] as? NSDictionary else {
+            resolve(Errors.createError(code: CommonErrorType.InvalidRequiredParameter, message: "You must provide paymentIntent that was returned from either createPaymentIntent or retrievePaymentIntent."))
+            return
+        }
+        guard let uuid = paymentIntentJSON["sdkUuid"] as? String else {
             resolve(Errors.createError(code: CommonErrorType.InvalidRequiredParameter, message: "The PaymentIntent is missing sdkUuid field. This method requires you to use the PaymentIntent that was returned from either createPaymentIntent or retrievePaymentIntent."))
             return
         }

--- a/ios/StripeTerminalReactNative.swift
+++ b/ios/StripeTerminalReactNative.swift
@@ -631,11 +631,11 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, BluetoothRe
 
     @objc(confirmPaymentIntent:resolver:rejecter:)
     func confirmPaymentIntent(params: NSDictionary, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
-        guard let paymentIntentJSON = params["paymentIntent"] as? NSDictionary else {
+        guard let paymentIntentJson = params["paymentIntent"] as? NSDictionary else {
             resolve(Errors.createError(code: CommonErrorType.InvalidRequiredParameter, message: "You must provide paymentIntent that was returned from either createPaymentIntent or retrievePaymentIntent."))
             return
         }
-        guard let uuid = paymentIntentJSON["sdkUuid"] as? String else {
+        guard let uuid = paymentIntentJson["sdkUuid"] as? String else {
             resolve(Errors.createError(code: CommonErrorType.InvalidRequiredParameter, message: "The PaymentIntent is missing sdkUuid field. This method requires you to use the PaymentIntent that was returned from either createPaymentIntent or retrievePaymentIntent."))
             return
         }
@@ -865,7 +865,11 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, BluetoothRe
     }
 
     @objc(confirmSetupIntent:resolver:rejecter:)
-    func confirmSetupIntent(setupIntentJson: NSDictionary, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+    func confirmSetupIntent(params: NSDictionary, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+        guard let setupIntentJson = params["setupIntent"] as? NSDictionary else {
+            resolve(Errors.createError(code: CommonErrorType.InvalidRequiredParameter, message: "You must provide setupIntent."))
+            return
+        }
         guard let uuid = setupIntentJson["sdkUuid"] as? String else {
             resolve(Errors.createError(code: CommonErrorType.InvalidRequiredParameter, message: "The SetupIntent is missing sdkUuid field. This method requires you to use the SetupIntent that was returned from either createPaymentIntent or retrievePaymentIntent."))
             return

--- a/ios/StripeTerminalReactNative.swift
+++ b/ios/StripeTerminalReactNative.swift
@@ -776,7 +776,11 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, BluetoothRe
     }
 
     @objc(cancelSetupIntent:resolver:rejecter:)
-    func cancelSetupIntent(setupIntentJson: NSDictionary, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+    func cancelSetupIntent(params: NSDictionary, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+        guard let setupIntentJson = params["setupIntent"] as? NSDictionary else {
+            resolve(Errors.createError(code: CommonErrorType.InvalidRequiredParameter, message: "You must provide setupIntent."))
+            return
+        }
         guard let uuid = setupIntentJson["sdkUuid"] as? String else {
             resolve(Errors.createError(code: CommonErrorType.InvalidRequiredParameter, message: "The SetupIntent is missing sdkUuid field. This method requires you to use the SetupIntent that was returned from either createPaymentIntent or retrievePaymentIntent."))
             return

--- a/src/StripeTerminalSdk.tsx
+++ b/src/StripeTerminalSdk.tsx
@@ -36,6 +36,7 @@ import type {
   PaymentStatus,
   ConnectionStatus,
   ConfirmPaymentMethodParams,
+  ConfirmSetupIntentMethodParams,
 } from './types';
 
 const { StripeTerminalReactNative } = NativeModules;
@@ -125,7 +126,7 @@ export interface StripeTerminalSdkType {
   getLocations(params: GetLocationsParams): Promise<GetLocationsResultType>;
   // Confirm Setup Intent
   confirmSetupIntent(
-    setupIntent: SetupIntent.Type
+    params: ConfirmSetupIntentMethodParams
   ): Promise<SetupIntentResultType>;
   simulateReaderUpdate(update: Reader.SimulateUpdateType): Promise<void>;
   collectRefundPaymentMethod(

--- a/src/StripeTerminalSdk.tsx
+++ b/src/StripeTerminalSdk.tsx
@@ -28,7 +28,6 @@ import type {
   ConnectLocalMobileParams,
   ConnectReaderResultType,
   CollectPaymentMethodParams,
-  PaymentIntent,
   OfflineStatus,
   ICollectInputsParameters,
   ICollectInputsResults,
@@ -37,6 +36,7 @@ import type {
   ConfirmPaymentMethodParams,
   ConfirmSetupIntentMethodParams,
   CancelSetupIntentMethodParams,
+  CancelPaymentMethodParams,
 } from './types';
 
 const { StripeTerminalReactNative } = NativeModules;
@@ -101,7 +101,7 @@ export interface StripeTerminalSdkType {
   ): Promise<SetupIntentResultType>;
   // Cancel Payment Intent
   cancelPaymentIntent(
-    paymentIntent: PaymentIntent.Type
+    params: CancelPaymentMethodParams
   ): Promise<PaymentIntentResultType>;
   // Collect Setup Intent payment method
   collectSetupIntentPaymentMethod(

--- a/src/StripeTerminalSdk.tsx
+++ b/src/StripeTerminalSdk.tsx
@@ -29,7 +29,6 @@ import type {
   ConnectReaderResultType,
   CollectPaymentMethodParams,
   PaymentIntent,
-  SetupIntent,
   OfflineStatus,
   ICollectInputsParameters,
   ICollectInputsResults,
@@ -37,6 +36,7 @@ import type {
   ConnectionStatus,
   ConfirmPaymentMethodParams,
   ConfirmSetupIntentMethodParams,
+  CancelSetupIntentMethodParams,
 } from './types';
 
 const { StripeTerminalReactNative } = NativeModules;
@@ -120,7 +120,7 @@ export interface StripeTerminalSdkType {
   retrieveSetupIntent(clientSecret: string): Promise<SetupIntentResultType>;
   // Cancel Setup Intent
   cancelSetupIntent(
-    setupIntent: SetupIntent.Type
+    params: CancelSetupIntentMethodParams
   ): Promise<SetupIntentResultType>;
   // List of locations belonging to the merchant
   getLocations(params: GetLocationsParams): Promise<GetLocationsResultType>;

--- a/src/StripeTerminalSdk.tsx
+++ b/src/StripeTerminalSdk.tsx
@@ -35,6 +35,7 @@ import type {
   ICollectInputsResults,
   PaymentStatus,
   ConnectionStatus,
+  ConfirmPaymentMethodParams,
 } from './types';
 
 const { StripeTerminalReactNative } = NativeModules;
@@ -91,7 +92,7 @@ export interface StripeTerminalSdkType {
   retrievePaymentIntent(clientSecret: string): Promise<PaymentIntentResultType>;
   // Confirm Payment Intent
   confirmPaymentIntent(
-    paymentIntentJson: PaymentIntent.Type
+    params: ConfirmPaymentMethodParams
   ): Promise<PaymentIntentResultType>;
   // Create Setup Intent
   createSetupIntent(

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -37,6 +37,7 @@ import type {
   PaymentStatus,
   ConnectionStatus,
   ConfirmPaymentMethodParams,
+  ConfirmSetupIntentMethodParams,
 } from './types';
 
 export async function initialize(
@@ -624,7 +625,7 @@ export async function cancelSetupIntent(
 }
 
 export async function confirmSetupIntent(
-  setupIntent: SetupIntent.Type
+  params: ConfirmSetupIntentMethodParams
 ): Promise<SetupIntentResultType> {
   return Logger.traceSdkMethod(async (innerSetupIntent) => {
     try {
@@ -646,7 +647,7 @@ export async function confirmSetupIntent(
         error: error as any,
       };
     }
-  }, 'confirmSetupIntent')(setupIntent);
+  }, 'confirmSetupIntent')(params);
 }
 
 export async function simulateReaderUpdate(

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -30,7 +30,6 @@ import type {
   ConnectHandoffParams,
   CollectPaymentMethodParams,
   PaymentIntent,
-  SetupIntent,
   OfflineStatus,
   ICollectInputsParameters,
   ICollectInputsResults,
@@ -38,6 +37,7 @@ import type {
   ConnectionStatus,
   ConfirmPaymentMethodParams,
   ConfirmSetupIntentMethodParams,
+  CancelSetupIntentMethodParams,
 } from './types';
 
 export async function initialize(
@@ -599,12 +599,12 @@ export async function clearReaderDisplay(): Promise<ClearReaderDisplayResultType
 }
 
 export async function cancelSetupIntent(
-  setupIntent: SetupIntent.Type
+  params: CancelSetupIntentMethodParams
 ): Promise<SetupIntentResultType> {
-  return Logger.traceSdkMethod(async (innerSetupIntent) => {
+  return Logger.traceSdkMethod(async (innerParams) => {
     try {
       const { setupIntent: canceledSetupIntent, error } =
-        await StripeTerminalSdk.cancelSetupIntent(innerSetupIntent);
+        await StripeTerminalSdk.cancelSetupIntent(innerParams);
 
       if (error) {
         return {
@@ -621,7 +621,7 @@ export async function cancelSetupIntent(
         error: error as any,
       };
     }
-  }, 'cancelSetupIntent')(setupIntent);
+  }, 'cancelSetupIntent')(params);
 }
 
 export async function confirmSetupIntent(

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -627,10 +627,10 @@ export async function cancelSetupIntent(
 export async function confirmSetupIntent(
   params: ConfirmSetupIntentMethodParams
 ): Promise<SetupIntentResultType> {
-  return Logger.traceSdkMethod(async (innerSetupIntent) => {
+  return Logger.traceSdkMethod(async (innerparams) => {
     try {
       const { setupIntent: confirmedSetupIntent, error } =
-        await StripeTerminalSdk.confirmSetupIntent(innerSetupIntent);
+        await StripeTerminalSdk.confirmSetupIntent(innerparams);
 
       if (error) {
         return {

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -29,7 +29,6 @@ import type {
   ConnectReaderResultType,
   ConnectHandoffParams,
   CollectPaymentMethodParams,
-  PaymentIntent,
   OfflineStatus,
   ICollectInputsParameters,
   ICollectInputsResults,
@@ -38,6 +37,7 @@ import type {
   ConfirmPaymentMethodParams,
   ConfirmSetupIntentMethodParams,
   CancelSetupIntentMethodParams,
+  CancelPaymentMethodParams,
 } from './types';
 
 export async function initialize(
@@ -456,12 +456,12 @@ export async function confirmPaymentIntent(
 }
 
 export async function cancelPaymentIntent(
-  paymentIntent: PaymentIntent.Type
+  params: CancelPaymentMethodParams
 ): Promise<PaymentIntentResultType> {
-  return Logger.traceSdkMethod(async (innerPaymentIntent) => {
+  return Logger.traceSdkMethod(async (innerparams) => {
     try {
       const { paymentIntent: canceledPaymentIntent, error } =
-        await StripeTerminalSdk.cancelPaymentIntent(innerPaymentIntent);
+        await StripeTerminalSdk.cancelPaymentIntent(innerparams);
 
       if (error) {
         return {
@@ -478,7 +478,7 @@ export async function cancelPaymentIntent(
         error: error as any,
       };
     }
-  }, 'cancelPaymentIntent')(paymentIntent);
+  }, 'cancelPaymentIntent')(params);
 }
 
 export async function installAvailableUpdate(): Promise<{

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -36,6 +36,7 @@ import type {
   ICollectInputsResults,
   PaymentStatus,
   ConnectionStatus,
+  ConfirmPaymentMethodParams,
 } from './types';
 
 export async function initialize(
@@ -422,15 +423,15 @@ export async function getLocations(
 }
 
 export async function confirmPaymentIntent(
-  paymentIntent: PaymentIntent.Type
+  params: ConfirmPaymentMethodParams
 ): Promise<PaymentIntentResultType> {
-  return Logger.traceSdkMethod(async (innerPaymentIntent) => {
+  return Logger.traceSdkMethod(async (innerparams) => {
     try {
       const { error, paymentIntent: confirmedPaymentIntent } =
-        await StripeTerminalSdk.confirmPaymentIntent(innerPaymentIntent);
+        await StripeTerminalSdk.confirmPaymentIntent(innerparams);
 
       if (error) {
-        if (paymentIntent) {
+        if (confirmedPaymentIntent) {
           return {
             error,
             paymentIntent: confirmedPaymentIntent,
@@ -450,7 +451,7 @@ export async function confirmPaymentIntent(
         error: error as any,
       };
     }
-  }, 'confirmPaymentIntent')(paymentIntent);
+  }, 'confirmPaymentIntent')(params);
 }
 
 export async function cancelPaymentIntent(

--- a/src/hooks/useStripeTerminal.tsx
+++ b/src/hooks/useStripeTerminal.tsx
@@ -23,6 +23,7 @@ import type {
   OfflineStatus,
   ICollectInputsParameters,
   ReaderEvent,
+  ConfirmPaymentMethodParams,
 } from '../types';
 import {
   discoverReaders,
@@ -608,14 +609,14 @@ export function useStripeTerminal(props?: Props) {
   );
 
   const _confirmPaymentIntent = useCallback(
-    async (paymentIntent: PaymentIntent.Type) => {
+    async (param: ConfirmPaymentMethodParams) => {
       if (!_isInitialized()) {
         console.error(NOT_INITIALIZED_ERROR_MESSAGE);
         throw Error(NOT_INITIALIZED_ERROR_MESSAGE);
       }
       setLoading(true);
 
-      const response = await confirmPaymentIntent(paymentIntent);
+      const response = await confirmPaymentIntent(param);
 
       setLoading(false);
 

--- a/src/hooks/useStripeTerminal.tsx
+++ b/src/hooks/useStripeTerminal.tsx
@@ -19,12 +19,12 @@ import type {
   UserCallbacks,
   EventResult,
   PaymentIntent,
-  SetupIntent,
   OfflineStatus,
   ICollectInputsParameters,
   ReaderEvent,
   ConfirmPaymentMethodParams,
   ConfirmSetupIntentMethodParams,
+  CancelSetupIntentMethodParams,
 } from '../types';
 import {
   discoverReaders,
@@ -751,14 +751,14 @@ export function useStripeTerminal(props?: Props) {
   }, [setLoading, _isInitialized]);
 
   const _cancelSetupIntent = useCallback(
-    async (setupIntent: SetupIntent.Type) => {
+    async (params: CancelSetupIntentMethodParams) => {
       if (!_isInitialized()) {
         console.error(NOT_INITIALIZED_ERROR_MESSAGE);
         throw Error(NOT_INITIALIZED_ERROR_MESSAGE);
       }
       setLoading(true);
 
-      const response = await cancelSetupIntent(setupIntent);
+      const response = await cancelSetupIntent(params);
 
       setLoading(false);
 

--- a/src/hooks/useStripeTerminal.tsx
+++ b/src/hooks/useStripeTerminal.tsx
@@ -25,6 +25,7 @@ import type {
   ConfirmPaymentMethodParams,
   ConfirmSetupIntentMethodParams,
   CancelSetupIntentMethodParams,
+  CancelPaymentMethodParams,
 } from '../types';
 import {
   discoverReaders,
@@ -644,14 +645,14 @@ export function useStripeTerminal(props?: Props) {
   );
 
   const _cancelPaymentIntent = useCallback(
-    async (paymentIntent: PaymentIntent.Type) => {
+    async (params: CancelPaymentMethodParams) => {
       if (!_isInitialized()) {
         console.error(NOT_INITIALIZED_ERROR_MESSAGE);
         throw Error(NOT_INITIALIZED_ERROR_MESSAGE);
       }
       setLoading(true);
 
-      const response = await cancelPaymentIntent(paymentIntent);
+      const response = await cancelPaymentIntent(params);
 
       setLoading(false);
 

--- a/src/hooks/useStripeTerminal.tsx
+++ b/src/hooks/useStripeTerminal.tsx
@@ -24,6 +24,7 @@ import type {
   ICollectInputsParameters,
   ReaderEvent,
   ConfirmPaymentMethodParams,
+  ConfirmSetupIntentMethodParams,
 } from '../types';
 import {
   discoverReaders,
@@ -767,14 +768,14 @@ export function useStripeTerminal(props?: Props) {
   );
 
   const _confirmSetupIntent = useCallback(
-    async (setupIntent: SetupIntent.Type) => {
+    async (params: ConfirmSetupIntentMethodParams) => {
       if (!_isInitialized()) {
         console.error(NOT_INITIALIZED_ERROR_MESSAGE);
         throw Error(NOT_INITIALIZED_ERROR_MESSAGE);
       }
       setLoading(true);
 
-      const response = await confirmSetupIntent(setupIntent);
+      const response = await confirmSetupIntent(params);
 
       setLoading(false);
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -200,6 +200,10 @@ export type ConfirmPaymentMethodParams = {
   paymentIntent: PaymentIntent.Type;
 };
 
+export type ConfirmSetupIntentMethodParams = {
+  setupIntent: SetupIntent.Type;
+};
+
 export type CollectSetupIntentPaymentMethodParams = {
   customerConsentCollected?: boolean;
   enableCustomerCancellation?: boolean;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -204,6 +204,10 @@ export type ConfirmSetupIntentMethodParams = {
   setupIntent: SetupIntent.Type;
 };
 
+export type CancelSetupIntentMethodParams = {
+  setupIntent: SetupIntent.Type;
+};
+
 export type CollectSetupIntentPaymentMethodParams = {
   customerConsentCollected?: boolean;
   enableCustomerCancellation?: boolean;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -200,6 +200,10 @@ export type ConfirmPaymentMethodParams = {
   paymentIntent: PaymentIntent.Type;
 };
 
+export type CancelPaymentMethodParams = {
+  paymentIntent: PaymentIntent.Type;
+};
+
 export type ConfirmSetupIntentMethodParams = {
   setupIntent: SetupIntent.Type;
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -196,6 +196,10 @@ export type CollectPaymentMethodParams = {
   requestDynamicCurrencyConversion?: boolean;
 };
 
+export type ConfirmPaymentMethodParams = {
+  paymentIntent: PaymentIntent.Type;
+};
+
 export type CollectSetupIntentPaymentMethodParams = {
   customerConsentCollected?: boolean;
   enableCustomerCancellation?: boolean;


### PR DESCRIPTION
## Summary

Addresses discrepancy in the input shape of the `confirm` methods compared to other PI calls. The `confirm` method currently does not use a params object, unlike the other PI calls.

## Motivation

Align the input parameters of the "confirm" methods with the input shapes of other PI calls to ensure consistency in API calls.

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
