### PR TITLE
Fix required param name for collectInputs

### DIFF
--- a/ios/StripeTerminalReactNative.swift
+++ b/ios/StripeTerminalReactNative.swift
@@ -409,7 +409,7 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, BluetoothRe
             .setCustomer(customer)
             .setTransferGroup(transferGroup)
             .setMetadata(metadata)
-        
+
         if !paymentMethodTypes.isEmpty {
             paymentParamsBuilder.setPaymentMethodTypes(paymentMethodTypes)
         }
@@ -972,7 +972,7 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, BluetoothRe
 
         resolve(result)
     }
-    
+
     @objc(getPaymentStatus:rejecter:)
     func getPaymentStatus(resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
         let result = Mappers.mapFromPaymentStatus(Terminal.shared.paymentStatus)
@@ -1000,7 +1000,7 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, BluetoothRe
 
     @objc(collectInputs:resolver:rejecter:)
     func collectInputs(_ params: NSDictionary, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
-        let invalidParams = Errors.validateRequiredParameters(params: params, requiredParams: ["collectInputs"])
+        let invalidParams = Errors.validateRequiredParameters(params: params, requiredParams: ["inputs"])
 
         guard invalidParams == nil else {
             resolve(Errors.createError(code: CommonErrorType.InvalidRequiredParameter, message: "You must provide \(invalidParams!) parameters."))


### PR DESCRIPTION
## Summary
We changed the parameter name from collectInputs and inputs in https://github.com/stripe/stripe-terminal-react-native/pull/721 but forgot to change the required param check in the native bridge.
<!-- Simple summary of what was changed. -->

## Motivation
Bug fix
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
