### PR TITLE
Disable jetifier for jackson-core by default

### DIFF
--- a/src/plugin/withStripeTerminal.ts
+++ b/src/plugin/withStripeTerminal.ts
@@ -4,6 +4,7 @@ import {
   IOSConfig,
   withInfoPlist,
   withAndroidManifest,
+  withGradleProperties,
   AndroidConfig,
 } from '@expo/config-plugins';
 
@@ -36,6 +37,7 @@ const withStripeTerminal: ConfigPlugin<StripeTerminalPluginProps> = (
   config = withStripeTerminalIos(config, props);
   config = withNoopSwiftFile(config);
   config = withStripeTerminalAndroid(config);
+  config = withJetifierIgnoringJackson(config);
 
   return config;
 };
@@ -44,6 +46,18 @@ const withStripeTerminalAndroid: ConfigPlugin = (expoConfig) => {
   return withAndroidManifest(expoConfig, (config) => {
     config.modResults = addBTPermissionToManifest(config.modResults);
     config.modResults = addLocationPermissionToManifest(config.modResults);
+
+    return config;
+  });
+};
+
+const withJetifierIgnoringJackson: ConfigPlugin = (expoConfig) => {
+  return withGradleProperties(expoConfig, (config) => {
+    config.modResults.push({
+      key: 'android.jetifier.ignorelist',
+      value: 'jackson-core',
+      type: 'property',
+    });
 
     return config;
   });


### PR DESCRIPTION
## Summary

Modify expo config ti disable jetifier for jackson-core by default.

## Motivation

To improve issue [https://github.com/stripe/stripe-terminal-react-native/issues/653](https://github.com/stripe/stripe-terminal-react-native/issues/653)

new gradle properties setup after improvement.
<img width="557" alt="image" src="https://github.com/stripe/stripe-terminal-react-native/assets/128665735/9b4cbb82-3fa1-44e8-ade7-be3145b4ff3d">

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
