### PR TITLE
Modify script to allow release from non-main branch

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -104,4 +104,9 @@ echo "Tagging and publishing release"
 yarn -s --ignore-scripts publish --access=public
 
 echo "Pushing git commit and tag"
-git push
+git push --follow-tags
+
+echo "Publish successful!"
+echo ""
+
+create_github_release

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -61,6 +61,11 @@ fi
 
 BRANCH_NAME=$1
 
+if [ "$BRANCH_NAME" = "main" ]; then
+  echo "Error! Cannot publish from the 'main' branch."
+  exit 1
+fi
+
 # Make sure our working dir is the repo root directory
 cd "$(git rev-parse --show-toplevel)"
 
@@ -99,9 +104,4 @@ echo "Tagging and publishing release"
 yarn -s --ignore-scripts publish --access=public
 
 echo "Pushing git commit and tag"
-git push --follow-tags
-
-echo "Publish successful!"
-echo ""
-
-create_github_release
+git push

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -6,7 +6,7 @@ IFS=$'\n\t'
 echo_help() {
   cat << EOF
 USAGE:
-    ./scripts/publish.sh
+    ./scripts/publish.sh <branch-name>
 EOF
 }
 
@@ -52,21 +52,14 @@ Remember to create a release on GitHub with a changelog notes:
 EOF
 }
 
-if [ $# -gt 0 ]; then
-  # Show help message if -h, --help, or help passed
-  case $1 in
-    -h | --help | help)
-      echo_help
-      exit 0
-      ;;
-    *)
-      echo "Invalid argument $1"
-      echo ""
-      echo_help
-      exit 1
-      ;;
-  esac
+if [ $# -ne 1 ]; then
+  echo "Error: Branch name is mandatory"
+  echo ""
+  echo_help
+  exit 1
 fi
+
+BRANCH_NAME=$1
 
 # Make sure our working dir is the repo root directory
 cd "$(git rev-parse --show-toplevel)"
@@ -74,15 +67,17 @@ cd "$(git rev-parse --show-toplevel)"
 echo "Fetching git remotes"
 git fetch
 
-GIT_STATUS=$(git status)
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
-if ! grep -q 'On branch main' <<< "$GIT_STATUS"; then
-  echo "Error! Must be on main branch to publish"
+if [ "$CURRENT_BRANCH" != "$BRANCH_NAME" ]; then
+  echo "Error! Must be on branch '$BRANCH_NAME' to publish"
   exit 1
 fi
 
-if ! grep -q "Your branch is up to date with 'origin/main'." <<< "$GIT_STATUS"; then
-  echo "Error! Must be up to date with origin/main to publish"
+GIT_STATUS=$(git status)
+
+if ! grep -q "Your branch is up to date with 'origin/$BRANCH_NAME'." <<< "$GIT_STATUS"; then
+  echo "Error! Must be up to date with origin/$BRANCH_NAME to publish"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
Publish script changes to force devs into typing the branch name when releasing and disables releases from the main branch to promote using release branches
<!-- Simple summary of what was changed. -->

## Motivation
KTLO
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [x] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
