### PR TITLE
Wire up ability to write iOS unit tests

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -15,6 +15,7 @@ stages:
       - typescript: {}
       - unit-js: {}
       - unit-android: {}
+      - unit-ios: {}
       - example-build-ios: {}
       - example-build-android: {}
       - e2e-android: {}
@@ -25,6 +26,7 @@ stages:
       - typescript: {}
       - unit-js: {}
       - unit-android: {}
+      - unit-ios: {}
       - example-build-ios: {}
       - example-build-android: {}
       - e2e-android: {}
@@ -89,18 +91,6 @@ workflows:
         machine_type_id: elite-xl
   e2e-ios:
     steps:
-      - bundler@0: {}
-      - script@1:
-          inputs:
-            - content: |-
-                set -e
-                # This is a terrible hack, as I haven't worked out how Bitrise's `pod install` step interacts with the rbenv set in this app. You definitely shouldn't copy this.
-                cd dev-app/ios && asdf install ruby 3.2.3 && bundle install && \
-                gem install cocoapods -v 1.15.2 && pod install && cd - && \
-                npm rebuild detox
-                echo "Checking for diffs in pod lockfile, if this fails please ensure all dependencies are up to date" && \
-                git diff --exit-code
-          title: Set up cocoapods
       - yarn@0:
           inputs:
             - command: e2e:build:ios:release
@@ -113,6 +103,7 @@ workflows:
           title: test detox
     before_run:
       - prep_all
+      - setup_cocoapods
     after_run:
       - complete_all
   example-build-android:
@@ -214,6 +205,20 @@ workflows:
                 echo "Checking for diffs in yarn lockfile, if this fails please ensure all dependencies are up to date"
                 git diff --exit-code
           title: Check for diffs in yarn lockfile
+  setup_cocoapods:
+    steps:
+      - bundler@0: {}
+      - script@1:
+          inputs:
+            - content: |-
+                set -e
+                # This is a terrible hack, as I haven't worked out how Bitrise's `pod install` step interacts with the rbenv set in this app. You definitely shouldn't copy this.
+                cd dev-app/ios && asdf install ruby 3.2.3 && bundle install && \
+                gem install cocoapods -v 1.15.2 && pod install && cd - && \
+                npm rebuild detox
+                echo "Checking for diffs in pod lockfile, if this fails please ensure all dependencies are up to date" && \
+                git diff --exit-code
+          title: Set up cocoapods
   typescript:
     steps:
       - yarn@0:
@@ -251,6 +256,19 @@ workflows:
           title: yarn unit-test:js --coverage
     before_run:
       - prep_all
+    after_run:
+      - complete_all
+  unit-ios:
+    steps:
+    - xcode-test@5:
+        inputs:
+        - project_path: dev-app/ios/StripeTerminalReactNativeDevApp.xcworkspace
+        - scheme: UnitTests
+        - destination: platform=iOS Simulator,name=iPhone 14,OS=latest
+        title: xcodebuild iOS Unit Tests
+    before_run:
+      - prep_all
+      - setup_cocoapods
     after_run:
       - complete_all
 meta:

--- a/dev-app/ios/Podfile
+++ b/dev-app/ios/Podfile
@@ -41,7 +41,9 @@ target 'StripeTerminalReactNativeDevApp' do
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
 
-  pod 'stripe-terminal-react-native', path: '../..'
+  pod 'stripe-terminal-react-native',
+      path: '../..',
+      testspecs: ['Tests']
 
   post_install do |installer|
     # https://github.com/facebook/react-native/blob/main/packages/react-native/scripts/react_native_pods.rb#L197-L202

--- a/dev-app/ios/Podfile.lock
+++ b/dev-app/ios/Podfile.lock
@@ -441,6 +441,9 @@ PODS:
   - stripe-terminal-react-native (0.0.1-beta.19):
     - React-Core
     - StripeTerminal (~> 3.7.0)
+  - stripe-terminal-react-native/Tests (0.0.1-beta.19):
+    - React-Core
+    - StripeTerminal (~> 3.7.0)
   - StripeTerminal (3.7.0)
   - Yoga (1.14.0)
 
@@ -491,6 +494,7 @@ DEPENDENCIES:
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNScreens (from `../node_modules/react-native-screens`)
   - stripe-terminal-react-native (from `../..`)
+  - stripe-terminal-react-native/Tests (from `../..`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -640,10 +644,10 @@ SPEC CHECKSUMS:
   RNGestureHandler: 32a01c29ecc9bb0b5bf7bc0a33547f61b4dc2741
   RNScreens: 3c2d122f5e08c192e254c510b212306da97d2581
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  stripe-terminal-react-native: 6ef5eac07c17e9a07da2b40e9a653f21465baa80
+  stripe-terminal-react-native: 8ecf9e51fd9b84b15997fbfe794a65ce1e4bf828
   StripeTerminal: 7188b9f8bb3f3c9f0ad5f18217f26ccb07001988
   Yoga: 4c3aa327e4a6a23eeacd71f61c81df1bcdf677d5
 
-PODFILE CHECKSUM: 8b6a9ec02d405ae261b816f227c75d2138b656d5
+PODFILE CHECKSUM: e42df060dac549df682e535ef903a0f36c3e799c
 
 COCOAPODS: 1.15.2

--- a/dev-app/ios/StripeTerminalReactNativeDevApp.xcodeproj/project.pbxproj
+++ b/dev-app/ios/StripeTerminalReactNativeDevApp.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		00E356F31AD99517003FC87E /* StripeTerminalReactNativeDevAppTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* StripeTerminalReactNativeDevAppTests.m */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		2400A4F4282272D1005D6199 /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2400A4F3282272D1005D6199 /* AppDelegate.mm */; };
@@ -16,28 +15,12 @@
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 /* End PBXBuildFile section */
 
-/* Begin PBXContainerItemProxy section */
-		00E356F41AD99517003FC87E /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 83CBB9F71A601CBA00E9B192 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 13B07F861A680F5B00A75B9A;
-			remoteInfo = StripeTerminalReactNativeDevApp;
-		};
-/* End PBXContainerItemProxy section */
-
 /* Begin PBXFileReference section */
-		008F07F21AC5B25A0029DE68 /* main.jsbundle */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = main.jsbundle; sourceTree = "<group>"; };
-		00E356EE1AD99517003FC87E /* StripeTerminalReactNativeDevAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StripeTerminalReactNativeDevAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		00E356F11AD99517003FC87E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		00E356F21AD99517003FC87E /* StripeTerminalReactNativeDevAppTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = StripeTerminalReactNativeDevAppTests.m; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* StripeTerminalReactNativeDevApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = StripeTerminalReactNativeDevApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = StripeTerminalReactNativeDevApp/AppDelegate.h; sourceTree = "<group>"; };
-		13B07FB01A68108700A75B9A /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = StripeTerminalReactNativeDevApp/AppDelegate.m; sourceTree = "<group>"; };
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = StripeTerminalReactNativeDevApp/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = StripeTerminalReactNativeDevApp/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = StripeTerminalReactNativeDevApp/main.m; sourceTree = "<group>"; };
-		2400A4F128227124005D6199 /* AppDelegate.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = AppDelegate.mm; sourceTree = "<group>"; };
 		2400A4F3282272D1005D6199 /* AppDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = AppDelegate.mm; path = StripeTerminalReactNativeDevApp/AppDelegate.mm; sourceTree = "<group>"; };
 		24C7E185271805C30025FC13 /* StripeTerminalReactNativeDevApp-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "StripeTerminalReactNativeDevApp-Bridging-Header.h"; sourceTree = "<group>"; };
 		24C7E186271805C30025FC13 /* Empty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Empty.swift; sourceTree = "<group>"; };
@@ -51,13 +34,6 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		00E356EB1AD99517003FC87E /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		13B07F8C1A680F5B00A75B9A /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -69,37 +45,17 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		00E356EF1AD99517003FC87E /* StripeTerminalReactNativeDevAppTests */ = {
-			isa = PBXGroup;
-			children = (
-				00E356F21AD99517003FC87E /* StripeTerminalReactNativeDevAppTests.m */,
-				00E356F01AD99517003FC87E /* Supporting Files */,
-			);
-			path = StripeTerminalReactNativeDevAppTests;
-			sourceTree = "<group>";
-		};
-		00E356F01AD99517003FC87E /* Supporting Files */ = {
-			isa = PBXGroup;
-			children = (
-				00E356F11AD99517003FC87E /* Info.plist */,
-			);
-			name = "Supporting Files";
-			sourceTree = "<group>";
-		};
 		13B07FAE1A68108700A75B9A /* StripeTerminalReactNativeDevApp */ = {
 			isa = PBXGroup;
 			children = (
-				2400A4F3282272D1005D6199 /* AppDelegate.mm */,
-				008F07F21AC5B25A0029DE68 /* main.jsbundle */,
 				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
-				13B07FB01A68108700A75B9A /* AppDelegate.m */,
+				2400A4F3282272D1005D6199 /* AppDelegate.mm */,
+				24C7E186271805C30025FC13 /* Empty.swift */,
 				13B07FB51A68108700A75B9A /* Images.xcassets */,
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */,
 				13B07FB71A68108700A75B9A /* main.m */,
-				24C7E186271805C30025FC13 /* Empty.swift */,
 				24C7E185271805C30025FC13 /* StripeTerminalReactNativeDevApp-Bridging-Header.h */,
-				2400A4F128227124005D6199 /* AppDelegate.mm */,
 			);
 			name = StripeTerminalReactNativeDevApp;
 			sourceTree = "<group>";
@@ -136,7 +92,6 @@
 				C251B19429BC224000E3E4A2 /* stripe_terminal_react_native_dev_app.entitlements */,
 				13B07FAE1A68108700A75B9A /* StripeTerminalReactNativeDevApp */,
 				832341AE1AAA6A7D00B99B32 /* Libraries */,
-				00E356EF1AD99517003FC87E /* StripeTerminalReactNativeDevAppTests */,
 				83CBBA001A601CBA00E9B192 /* Products */,
 				2D16E6871FA4F8E400B85C8A /* Frameworks */,
 				6B9684456A2045ADE5A6E47E /* Pods */,
@@ -150,7 +105,6 @@
 			isa = PBXGroup;
 			children = (
 				13B07F961A680F5B00A75B9A /* StripeTerminalReactNativeDevApp.app */,
-				00E356EE1AD99517003FC87E /* StripeTerminalReactNativeDevAppTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -158,24 +112,6 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		00E356ED1AD99517003FC87E /* StripeTerminalReactNativeDevAppTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 00E357021AD99517003FC87E /* Build configuration list for PBXNativeTarget "StripeTerminalReactNativeDevAppTests" */;
-			buildPhases = (
-				00E356EA1AD99517003FC87E /* Sources */,
-				00E356EB1AD99517003FC87E /* Frameworks */,
-				00E356EC1AD99517003FC87E /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				00E356F51AD99517003FC87E /* PBXTargetDependency */,
-			);
-			name = StripeTerminalReactNativeDevAppTests;
-			productName = StripeTerminalReactNativeDevAppTests;
-			productReference = 00E356EE1AD99517003FC87E /* StripeTerminalReactNativeDevAppTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
 		13B07F861A680F5B00A75B9A /* StripeTerminalReactNativeDevApp */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "StripeTerminalReactNativeDevApp" */;
@@ -206,11 +142,6 @@
 			attributes = {
 				LastUpgradeCheck = 1130;
 				TargetAttributes = {
-					00E356ED1AD99517003FC87E = {
-						CreatedOnToolsVersion = 6.2;
-						DevelopmentTeam = Y28TH9SHX7;
-						TestTargetID = 13B07F861A680F5B00A75B9A;
-					};
 					13B07F861A680F5B00A75B9A = {
 						DevelopmentTeam = Y28TH9SHX7;
 						LastSwiftMigration = 1250;
@@ -231,19 +162,11 @@
 			projectRoot = "";
 			targets = (
 				13B07F861A680F5B00A75B9A /* StripeTerminalReactNativeDevApp */,
-				00E356ED1AD99517003FC87E /* StripeTerminalReactNativeDevAppTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		00E356EC1AD99517003FC87E /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		13B07F8E1A680F5B00A75B9A /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -352,14 +275,6 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		00E356EA1AD99517003FC87E /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				00E356F31AD99517003FC87E /* StripeTerminalReactNativeDevAppTests.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		13B07F871A680F5B00A75B9A /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -372,60 +287,7 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
-/* Begin PBXTargetDependency section */
-		00E356F51AD99517003FC87E /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 13B07F861A680F5B00A75B9A /* StripeTerminalReactNativeDevApp */;
-			targetProxy = 00E356F41AD99517003FC87E /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
-
 /* Begin XCBuildConfiguration section */
-		00E356F61AD99517003FC87E /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				DEVELOPMENT_TEAM = Y28TH9SHX7;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				INFOPLIST_FILE = StripeTerminalReactNativeDevAppTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				OTHER_LDFLAGS = (
-					"-ObjC",
-					"-lc++",
-					"$(inherited)",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.dev.app.stripeterminalreactnative;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/StripeTerminalReactNativeDevApp.app/StripeTerminalReactNativeDevApp";
-			};
-			name = Debug;
-		};
-		00E356F71AD99517003FC87E /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				COPY_PHASE_STRIP = NO;
-				DEVELOPMENT_TEAM = Y28TH9SHX7;
-				INFOPLIST_FILE = StripeTerminalReactNativeDevAppTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				OTHER_LDFLAGS = (
-					"-ObjC",
-					"-lc++",
-					"$(inherited)",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.dev.app.stripeterminalreactnative;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/StripeTerminalReactNativeDevApp.app/StripeTerminalReactNativeDevApp";
-			};
-			name = Release;
-		};
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 47F7ED3B7971BE374F7B8635 /* Pods-StripeTerminalReactNativeDevApp.debug.xcconfig */;
@@ -620,15 +482,6 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		00E357021AD99517003FC87E /* Build configuration list for PBXNativeTarget "StripeTerminalReactNativeDevAppTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				00E356F61AD99517003FC87E /* Debug */,
-				00E356F71AD99517003FC87E /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 		13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "StripeTerminalReactNativeDevApp" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/dev-app/ios/StripeTerminalReactNativeDevApp.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
+++ b/dev-app/ios/StripeTerminalReactNativeDevApp.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1520"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6886BC3DBF76C9D4427F3C9303C50D58"
+               BuildableName = "stripe-terminal-react-native-Unit-Tests.xctest"
+               BlueprintName = "stripe-terminal-react-native-Unit-Tests"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios/Tests/MappersTests.swift
+++ b/ios/Tests/MappersTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+
+@testable import stripe_terminal_react_native
+import StripeTerminal
+
+final class MappersTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testLocationStatusMapper() {
+        // bric note: Just an example, this isn't really a useful test since this mapper just maps from
+        // and to constants
+        XCTAssertEqual(Mappers.mapFromLocationStatus(.notSet), "notSet")
+    }
+
+}

--- a/stripe-terminal-react-native.podspec
+++ b/stripe-terminal-react-native.podspec
@@ -14,6 +14,11 @@ Pod::Spec.new do |s|
   s.source       = { git: 'https://github.com/stripe/stripe-terminal-react-native.git', tag: s.version.to_s }
 
   s.source_files = 'ios/**/*.{h,m,mm,swift}'
+  s.exclude_files = 'ios/Tests/'
+
+  s.test_spec 'Tests' do |test_spec|
+    test_spec.source_files = 'ios/Tests/**/*.{m,swift}'
+  end
 
   s.dependency 'React-Core'
   s.dependency 'StripeTerminal', '~> 3.7.0'


### PR DESCRIPTION
## Summary
Followed along with how stripe-react-native has things setup.

- The .podspec specifies the tests and excludes them from the main sources
- The Podfile sets up a test target
- Create a new UnitTests scheme in the xcworkspace that builds and tests from the new target
- import the stripe_terminal_react_native as a `@testable import...` so the classes are exposed
- write tests

I wrote a very simple, not very useful, test on the location status mapper as an example.

<!-- Simple summary of what was changed. -->

## Motivation
tests!
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

## Testing
CI
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [ ] I tested this manually
- [x] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
