### PR TITLE
Fix Mismatch between documentation and types file when calling createSetupIntent

### DIFF
--- a/dev-app/src/screens/SetupIntentScreen.tsx
+++ b/dev-app/src/screens/SetupIntentScreen.tsx
@@ -233,7 +233,7 @@ export default function SetupIntentScreen() {
       }
 
       const response = await createSetupIntent({
-        customerId: resp.id,
+        customer: resp.id,
       });
       setupIntent = response.setupIntent;
       setupIntentError = response.error;

--- a/ios/StripeTerminalReactNative.swift
+++ b/ios/StripeTerminalReactNative.swift
@@ -491,7 +491,7 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, BluetoothRe
         let setupIntentParams: SetupIntentParameters
         do {
             setupIntentParams = try SetupIntentParametersBuilder()
-                .setCustomer(params["customerId"] as? String)
+                .setCustomer(params["customer"] as? String)
                 .build()
         } catch {
             resolve(Errors.createError(nsError: error as NSError))

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -221,7 +221,7 @@ export type CollectSetupIntentPaymentMethodParams = {
 };
 
 export type CreateSetupIntentParams = {
-  customerId?: string;
+  customer?: string;
 };
 
 export type PaymentIntentResultType =


### PR DESCRIPTION
## Summary

Fix mismatch attributes between createSetupIntent and API document.

## Motivation

Maintaining consistency between API and documentation.

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
