### PR TITLE
Integrate ios local mobile terms of service accept callback

### DIFF
--- a/dev-app/src/screens/DiscoverReadersScreen.tsx
+++ b/dev-app/src/screens/DiscoverReadersScreen.tsx
@@ -94,6 +94,9 @@ export default function DiscoverReadersScreen() {
     onDidReportAvailableUpdate: (update) => {
       Alert.alert('New update is available', update.deviceSoftwareVersion);
     },
+    onDidAcceptTermsOfService: () => {
+      Alert.alert('Accept terms of Service');
+    },
   });
 
   const isBTReader = (reader: Reader.Type) =>

--- a/ios/StripeTerminalReactNative.swift
+++ b/ios/StripeTerminalReactNative.swift
@@ -24,6 +24,7 @@ enum ReactNativeConstants: String, CaseIterable {
     case UPDATE_BATTERY_LEVEL = "didUpdateBatteryLevel"
     case REPORT_LOW_BATTERY_WARNING = "didReportLowBatteryWarning"
     case REPORT_READER_EVENT = "didReportReaderEvent"
+    case ACCEPT_TERMS_OF_SERVICE = "didAcceptTermsOfService"
 }
 
 @objc(StripeTerminalReactNative)
@@ -371,6 +372,10 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, BluetoothRe
     func terminal(_ terminal: Terminal, didReportUnexpectedReaderDisconnect reader: Reader) {
         let error = Errors.createError(code: ErrorCode.unexpectedSdkError, message: "Reader has been disconnected unexpectedly")
         sendEvent(withName: ReactNativeConstants.REPORT_UNEXPECTED_READER_DISCONNECT.rawValue, body: error)
+    }
+
+    func localMobileReaderDidAcceptTermsOfService(_ reader: Reader) {
+        sendEvent(withName: ReactNativeConstants.ACCEPT_TERMS_OF_SERVICE.rawValue, body: ["reader": reader])
     }
 
     @objc(createPaymentIntent:resolver:rejecter:)

--- a/src/hooks/useStripeTerminal.tsx
+++ b/src/hooks/useStripeTerminal.tsx
@@ -101,6 +101,7 @@ export const {
   UPDATE_BATTERY_LEVEL,
   REPORT_LOW_BATTERY_WARNING,
   REPORT_READER_EVENT,
+  ACCEPT_TERMS_OF_SERVICE,
 } = NativeModules.StripeTerminalReactNative.getConstants();
 
 const NOT_INITIALIZED_ERROR_MESSAGE =
@@ -165,6 +166,7 @@ export function useStripeTerminal(props?: Props) {
     onDidUpdateBatteryLevel,
     onDidReportLowBatteryWarning,
     onDidReportReaderEvent,
+    onDidAcceptTermsOfService,
   } = props || {};
 
   const _discoverReaders = useCallback(
@@ -345,6 +347,10 @@ export function useStripeTerminal(props?: Props) {
     [onDidReportReaderEvent]
   );
 
+  const acceptTermsOfService = useCallback(() => {
+    onDidAcceptTermsOfService?.();
+  }, [onDidAcceptTermsOfService]);
+
   useListener(REPORT_AVAILABLE_UPDATE, didReportAvailableUpdate);
   useListener(START_INSTALLING_UPDATE, didStartInstallingUpdate);
   useListener(REPORT_UPDATE_PROGRESS, didReportReaderSoftwareUpdateProgress);
@@ -374,6 +380,7 @@ export function useStripeTerminal(props?: Props) {
   useListener(UPDATE_BATTERY_LEVEL, didUpdateBatteryLevel);
   useListener(REPORT_LOW_BATTERY_WARNING, didReportLowBatteryWarning);
   useListener(REPORT_READER_EVENT, didReportReaderEvent);
+  useListener(ACCEPT_TERMS_OF_SERVICE, acceptTermsOfService);
 
   const _initialize = useCallback(async () => {
     if (!initialize || typeof initialize !== 'function') {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -375,6 +375,8 @@ export type UserCallbacks = {
   onDidUpdateBatteryLevel?(result: Reader.BatteryLevel): void;
   onDidReportLowBatteryWarning?(): void;
   onDidReportReaderEvent?(event: ReaderEvent): void;
+
+  onDidAcceptTermsOfService?(): void;
 };
 
 export namespace PaymentMethod {


### PR DESCRIPTION
## Summary

Add callback event when user accept the terms of service of using tap to play on iOS side.

## Motivation

Part of the request from https://bugs.bbpos.com/projects/SDK/issues/SDK-189
iOS ref: https://stripe.dev/stripe-terminal-ios/docs/Protocols/SCPLocalMobileReaderDelegate.html#/c:objc(pl)SCPLocalMobileReaderDelegate(im)localMobileReaderDidAcceptTermsOfService:

## Testing

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
