### PR TITLE
Add missing  locationId parameter in discoverReaders method 

### DIFF
--- a/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
@@ -196,6 +196,7 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
         val discoveryMethod = requireParam(mapToDiscoveryMethod(discoveryMethodParam)) {
             "Unknown discoveryMethod: $discoveryMethodParam"
         }
+        val locationId = params.getString("locationId")
 
         val listener = RNDiscoveryListener(
             context,
@@ -215,7 +216,8 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
                     getBoolean(params, "simulated")
                 )
                 DiscoveryMethod.INTERNET -> DiscoveryConfiguration.InternetDiscoveryConfiguration(
-                    isSimulated = getBoolean(params, "simulated")
+                    isSimulated = getBoolean(params, "simulated"),
+                    location = locationId
                 )
                 DiscoveryMethod.USB -> DiscoveryConfiguration.UsbDiscoveryConfiguration(
                     getInt(params, "timeout") ?: 0,

--- a/ios/Mappers.swift
+++ b/ios/Mappers.swift
@@ -140,14 +140,14 @@ class Mappers {
         return DiscoveryMethod.internet
     }
 
-    class func mapToDiscoveryConfiguration(_ discoveryMethod: String?, simulated: Bool, timeout: UInt) throws-> DiscoveryConfiguration {
+    class func mapToDiscoveryConfiguration(_ discoveryMethod: String?, simulated: Bool, locationId: String?, timeout: UInt) throws-> DiscoveryConfiguration {
         switch discoveryMethod {
         case "bluetoothScan":
             return try BluetoothScanDiscoveryConfigurationBuilder().setSimulated(simulated).setTimeout(timeout).build()
         case "bluetoothProximity":
             return try BluetoothProximityDiscoveryConfigurationBuilder().setSimulated(simulated).build()
         case "internet":
-            return try InternetDiscoveryConfigurationBuilder().setSimulated(simulated).build()
+            return try InternetDiscoveryConfigurationBuilder().setSimulated(simulated).setLocationId(locationId).build()
         case "localMobile":
             return try LocalMobileDiscoveryConfigurationBuilder().setSimulated(simulated).build()
         @unknown default:

--- a/ios/StripeTerminalReactNative.swift
+++ b/ios/StripeTerminalReactNative.swift
@@ -174,10 +174,11 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, BluetoothRe
         let simulated = params["simulated"] as? Bool
         let discoveryMethod = params["discoveryMethod"] as? String
         let timeout = params["timeout"] as? UInt ?? 0
+        let locationId = params["locationId"] as? String
 
         let config: DiscoveryConfiguration
         do {
-            config = try Mappers.mapToDiscoveryConfiguration(discoveryMethod, simulated: simulated ?? false, timeout: timeout)
+            config = try Mappers.mapToDiscoveryConfiguration(discoveryMethod, simulated: simulated ?? false,  locationId: locationId ?? nil, timeout: timeout)
         } catch {
             resolve(Errors.createError(nsError: error as NSError))
             return

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,6 +22,7 @@ export type LogLevelIOS = 'none' | 'verbose';
 export type LogLevelAndroid = 'none' | 'verbose' | 'error' | 'warning';
 
 export type DiscoverReadersParams = {
+  locationId?: string;
   timeout?: number;
   simulated?: boolean;
   discoveryMethod: Reader.DiscoveryMethod;


### PR DESCRIPTION
## Summary

Add missing  locationId parameter in discoverReaders method .

## Motivation

Support the discoverReaders method to accept locationId so that users can filter readers by it when using the Interent model

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
