### PR TITLE
Split useTerminal Callback into different group

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,12 +132,16 @@ import { useStripeTerminal } from '@stripe/stripe-terminal-react-native';
 export default function PaymentScreen() {
   const { discoverReaders, connectedReader, discoveredReaders } =
     useStripeTerminal({
-      onUpdateDiscoveredReaders: (readers) => {
-        // access to discovered readers
+      discoveryCallbacks: {
+        onUpdateDiscoveredReaders: (readers) => {
+          // access to discovered readers
+        },
       },
-      onDidChangeConnectionStatus: (status) => {
-        // access to the current connection status
-      },
+      terminalCallbacks: {
+        onDidChangeConnectionStatus: (status) => {
+          // access to the current connection status
+        },
+      }
     });
 
   useEffect(() => {

--- a/dev-app/src/screens/CollectCardPaymentScreen.tsx
+++ b/dev-app/src/screens/CollectCardPaymentScreen.tsx
@@ -113,30 +113,32 @@ export default function CollectCardPaymentScreen() {
     setSimulatedCard,
     getOfflineStatus,
   } = useStripeTerminal({
-    onDidRequestReaderInput: (input) => {
-      // @ts-ignore
-      setCancel((prev) => ({ ...prev, isDisabled: false }));
-      addLogs({
-        name: 'Collect Payment Method',
-        events: [
-          {
-            name: input.sort().join(' / '),
-            description: 'terminal.didRequestReaderInput',
-            onBack: cancelCollectPaymentMethod,
-          },
-        ],
-      });
-    },
-    onDidRequestReaderDisplayMessage: (message) => {
-      addLogs({
-        name: 'Collect Payment Method',
-        events: [
-          {
-            name: message,
-            description: 'terminal.didRequestReaderDisplayMessage',
-          },
-        ],
-      });
+    readerCallbacks: {
+      onDidRequestReaderInput: (input) => {
+        // @ts-ignore
+        setCancel((prev) => ({ ...prev, isDisabled: false }));
+        addLogs({
+          name: 'Collect Payment Method',
+          events: [
+            {
+              name: input.sort().join(' / '),
+              description: 'terminal.didRequestReaderInput',
+              onBack: cancelCollectPaymentMethod,
+            },
+          ],
+        });
+      },
+      onDidRequestReaderDisplayMessage: (message) => {
+        addLogs({
+          name: 'Collect Payment Method',
+          events: [
+            {
+              name: message,
+              description: 'terminal.didRequestReaderDisplayMessage',
+            },
+          ],
+        });
+      },
     },
   });
 

--- a/dev-app/src/screens/DiscoverReadersScreen.tsx
+++ b/dev-app/src/screens/DiscoverReadersScreen.tsx
@@ -64,41 +64,47 @@ export default function DiscoverReadersScreen() {
     connectLocalMobileReader,
     connectHandoffReader,
   } = useStripeTerminal({
-    onFinishDiscoveringReaders: (finishError) => {
-      if (finishError) {
-        console.error(
-          'Discover readers error',
-          `${finishError.code}, ${finishError.message}`
-        );
-        if (navigation.canGoBack()) {
-          navigation.goBack();
+    discoveryCallbacks: {
+      onFinishDiscoveringReaders: (finishError) => {
+        if (finishError) {
+          console.error(
+            'Discover readers error',
+            `${finishError.code}, ${finishError.message}`
+          );
+          if (navigation.canGoBack()) {
+            navigation.goBack();
+          }
+        } else {
+          console.log('onFinishDiscoveringReaders success');
         }
-      } else {
-        console.log('onFinishDiscoveringReaders success');
-      }
-      setDiscoveringLoading(false);
+        setDiscoveringLoading(false);
+      },
     },
-    onDidStartInstallingUpdate: (update) => {
-      navigation.navigate('UpdateReaderScreen', {
-        update,
-        reader: connectingReader,
-        onDidUpdate: () => {
-          setPendingUpdateInfo(null);
-          setTimeout(() => {
-            if (navigation.canGoBack()) {
-              navigation.goBack();
-            }
-          }, 500);
-        },
-        started: true,
-      });
+    readerCallbacks: {
+      onDidStartInstallingUpdate: (update) => {
+        navigation.navigate('UpdateReaderScreen', {
+          update,
+          reader: connectingReader,
+          onDidUpdate: () => {
+            setPendingUpdateInfo(null);
+            setTimeout(() => {
+              if (navigation.canGoBack()) {
+                navigation.goBack();
+              }
+            }, 500);
+          },
+          started: true,
+        });
+      },
+      onDidReportAvailableUpdate: (update) => {
+        setPendingUpdateInfo(update);
+        Alert.alert('New update is available', update.deviceSoftwareVersion);
+      },
     },
-    onDidReportAvailableUpdate: (update) => {
-      setPendingUpdateInfo(update);
-      Alert.alert('New update is available', update.deviceSoftwareVersion);
-    },
-    onDidAcceptTermsOfService: () => {
-      Alert.alert('Accept terms of Service');
+    localMobileReaderCallbacks: {
+      onDidAcceptTermsOfService: () => {
+        Alert.alert('Accept terms of Service');
+      },
     },
   });
 

--- a/dev-app/src/screens/RefundPaymentScreen.tsx
+++ b/dev-app/src/screens/RefundPaymentScreen.tsx
@@ -56,29 +56,31 @@ export default function RefundPaymentScreen() {
     confirmRefund,
     setSimulatedCard,
   } = useStripeTerminal({
-    onDidRequestReaderInput: (input) => {
-      addLogs({
-        name: 'Collect Refund Payment Method',
-        events: [
-          {
-            name: input.join(' / '),
-            description: 'terminal.didRequestReaderInput',
-            onBack: cancelCollectRefundPaymentMethod,
-          },
-        ],
-      });
-    },
-    onDidRequestReaderDisplayMessage: (message) => {
-      addLogs({
-        name: 'Collect Refund Payment Method',
-        events: [
-          {
-            name: message,
-            description: 'terminal.didRequestReaderDisplayMessage',
-          },
-        ],
-      });
-      console.log('message', message);
+    readerCallbacks: {
+      onDidRequestReaderInput: (input) => {
+        addLogs({
+          name: 'Collect Refund Payment Method',
+          events: [
+            {
+              name: input.join(' / '),
+              description: 'terminal.didRequestReaderInput',
+              onBack: cancelCollectRefundPaymentMethod,
+            },
+          ],
+        });
+      },
+      onDidRequestReaderDisplayMessage: (message) => {
+        addLogs({
+          name: 'Collect Refund Payment Method',
+          events: [
+            {
+              name: message,
+              description: 'terminal.didRequestReaderDisplayMessage',
+            },
+          ],
+        });
+        console.log('message', message);
+      },
     },
   });
 

--- a/dev-app/src/screens/RegisterInternetReaderScreen.tsx
+++ b/dev-app/src/screens/RegisterInternetReaderScreen.tsx
@@ -39,26 +39,28 @@ export default function RegisterInternetReaderScreen() {
 
   const { cancelDiscovering, discoverReaders, connectInternetReader } =
     useStripeTerminal({
-      onFinishDiscoveringReaders: (finishError) => {
-        if (finishError) {
-          console.error(
-            'Discover readers error',
-            `${finishError.code}, ${finishError.message}`
-          );
-          if (navigation.canGoBack()) {
-            navigation.goBack();
+      discoveryCallbacks: {
+        onFinishDiscoveringReaders: (finishError) => {
+          if (finishError) {
+            console.error(
+              'Discover readers error',
+              `${finishError.code}, ${finishError.message}`
+            );
+            if (navigation.canGoBack()) {
+              navigation.goBack();
+            }
+          } else {
+            console.log('onFinishDiscoveringReaders success');
           }
-        } else {
-          console.log('onFinishDiscoveringReaders success');
-        }
-      },
-      onUpdateDiscoveredReaders(readers) {
-        readers.map((reader) => {
-          if (reader.id === readerId) {
-            handleConnectInternetReader(reader);
-            return;
-          }
-        });
+        },
+        onUpdateDiscoveredReaders(readers) {
+          readers.map((reader) => {
+            if (reader.id === readerId) {
+              handleConnectInternetReader(reader);
+              return;
+            }
+          });
+        },
       },
     });
 

--- a/dev-app/src/screens/SetupIntentScreen.tsx
+++ b/dev-app/src/screens/SetupIntentScreen.tsx
@@ -32,28 +32,30 @@ export default function SetupIntentScreen() {
     retrieveSetupIntent,
     cancelCollectSetupIntent,
   } = useStripeTerminal({
-    onDidRequestReaderInput: (input) => {
-      addLogs({
-        name: 'Collect Setup Intent',
-        events: [
-          {
-            name: input.sort().join(' / '),
-            description: 'terminal.didRequestReaderInput',
-            onBack: cancelCollectSetupIntent,
-          },
-        ],
-      });
-    },
-    onDidRequestReaderDisplayMessage: (message) => {
-      addLogs({
-        name: 'Collect Setup Intent',
-        events: [
-          {
-            name: message,
-            description: 'terminal.didRequestReaderDisplayMessage',
-          },
-        ],
-      });
+    readerCallbacks: {
+      onDidRequestReaderInput: (input) => {
+        addLogs({
+          name: 'Collect Setup Intent',
+          events: [
+            {
+              name: input.sort().join(' / '),
+              description: 'terminal.didRequestReaderInput',
+              onBack: cancelCollectSetupIntent,
+            },
+          ],
+        });
+      },
+      onDidRequestReaderDisplayMessage: (message) => {
+        addLogs({
+          name: 'Collect Setup Intent',
+          events: [
+            {
+              name: message,
+              description: 'terminal.didRequestReaderDisplayMessage',
+            },
+          ],
+        });
+      },
     },
   });
 

--- a/dev-app/src/screens/UpdateReaderScreen.tsx
+++ b/dev-app/src/screens/UpdateReaderScreen.tsx
@@ -19,17 +19,19 @@ export default function UpdateReaderScreen() {
   const [currentProgress, setCurrentProgress] = useState<string>();
   const { cancelInstallingUpdate, installAvailableUpdate, connectedReader } =
     useStripeTerminal({
-      onDidReportReaderSoftwareUpdateProgress: (progress) => {
-        setCurrentProgress((Number(progress) * 100).toFixed(0).toString());
-      },
-      onDidFinishInstallingUpdate: () => {
-        params?.onDidUpdate();
-        if (navigation.canGoBack()) {
-          navigation.goBack();
-        }
-      },
-      onDidStartInstallingUpdate(_update) {
-        setStartToUpdate(true);
+      readerCallbacks: {
+        onDidReportReaderSoftwareUpdateProgress: (progress) => {
+          setCurrentProgress((Number(progress) * 100).toFixed(0).toString());
+        },
+        onDidFinishInstallingUpdate: () => {
+          params?.onDidUpdate();
+          if (navigation.canGoBack()) {
+            navigation.goBack();
+          }
+        },
+        onDidStartInstallingUpdate: (_update) => {
+          setStartToUpdate(true);
+        },
       },
     });
 

--- a/src/hooks/useStripeTerminal.tsx
+++ b/src/hooks/useStripeTerminal.tsx
@@ -123,11 +123,15 @@ export type Props = UserCallbacks;
  * @example
  * ```ts
  * const { discoverReaders } = useStripeTerminal({
- *   onUpdateDiscoveredReaders: (readers) => {
- *     setDisoveredReaders(readers)
- *   }
- *   onDidReportReaderSoftwareUpdateProgress: (progress) => {
- *     setCurrentProgress(progress)
+ *   discoveryCallbacks: {
+ *     onUpdateDiscoveredReaders: (readers) => {
+ *       setDisoveredReaders(readers)
+ *     }
+ *   },
+ *   readerCallbacks: {
+ *     onDidReportReaderSoftwareUpdateProgress: (progress) => {
+ *       setCurrentProgress(progress)
+ *     }
  *   }
  * })
  * ```
@@ -149,29 +153,40 @@ export function useStripeTerminal(props?: Props) {
   const _isInitialized = useCallback(() => isInitialized, [isInitialized]);
 
   const {
-    onUpdateDiscoveredReaders,
-    onFinishDiscoveringReaders,
+    onDidDisconnect,
     onDidFinishInstallingUpdate,
     onDidReportAvailableUpdate,
+    onDidReportLowBatteryWarning,
+    onDidReportReaderEvent,
     onDidReportReaderSoftwareUpdateProgress,
-    onDidReportUnexpectedReaderDisconnect,
-    onDidStartInstallingUpdate,
-    onDidRequestReaderInput,
     onDidRequestReaderDisplayMessage,
-    onDidChangePaymentStatus,
+    onDidRequestReaderInput,
+    onDidStartInstallingUpdate,
+    onDidUpdateBatteryLevel,
+  } = props?.readerCallbacks || {};
+
+  const {
     onDidChangeConnectionStatus,
+    onDidChangePaymentStatus,
+    onDidReportUnexpectedReaderDisconnect,
+  } = props?.terminalCallbacks || {};
+
+  const {
+    onDidFailReaderReconnect,
     onDidStartReaderReconnect,
     onDidSucceedReaderReconnect,
-    onDidFailReaderReconnect,
+  } = props?.reconnectionCallbacks || {};
+
+  const {
     onDidChangeOfflineStatus,
     onDidForwardPaymentIntent,
     onDidForwardingFailure,
-    onDidDisconnect,
-    onDidUpdateBatteryLevel,
-    onDidReportLowBatteryWarning,
-    onDidReportReaderEvent,
-    onDidAcceptTermsOfService,
-  } = props || {};
+  } = props?.offlineCallbacks || {};
+
+  const { onFinishDiscoveringReaders, onUpdateDiscoveredReaders } =
+    props?.discoveryCallbacks || {};
+
+  const { onDidAcceptTermsOfService } = props?.localMobileReaderCallbacks || {};
 
   const _discoverReaders = useCallback(
     async (params: DiscoverReadersParams) => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -348,37 +348,54 @@ export type EventResult<T> = {
 };
 
 export type UserCallbacks = {
-  onUpdateDiscoveredReaders?(readers: Reader.Type[]): void;
-  onFinishDiscoveringReaders?(error?: StripeError): void;
-  onDidReportUnexpectedReaderDisconnect?(error?: StripeError): void;
-  onDidReportAvailableUpdate?(update: Reader.SoftwareUpdate): void;
-  onDidStartInstallingUpdate?(update: Reader.SoftwareUpdate): void;
-  onDidReportReaderSoftwareUpdateProgress?(progress: string): void;
+  readerCallbacks?: ReaderCallbacks;
+  terminalCallbacks?: TerminalCallbacks;
+  reconnectionCallbacks?: ReconnectionCallbacks;
+  offlineCallbacks?: OfflineCallbacks;
+  discoveryCallbacks?: DiscoveryCallbacks;
+  localMobileReaderCallbacks?: LocalMobileReaderCallbacks;
+};
+
+export type ReaderCallbacks = {
+  onDidDisconnect?(reason?: Reader.DisconnectReason): void;
   onDidFinishInstallingUpdate?(result: UpdateSoftwareResultType): void;
-
-  onDidRequestReaderInput?(input: Reader.InputOptions[]): void;
+  onDidReportAvailableUpdate?(update: Reader.SoftwareUpdate): void;
+  onDidReportLowBatteryWarning?(): void;
+  onDidReportReaderEvent?(event: ReaderEvent): void;
+  onDidReportReaderSoftwareUpdateProgress?(progress: string): void;
   onDidRequestReaderDisplayMessage?(message: Reader.DisplayMessage): void;
+  onDidRequestReaderInput?(input: Reader.InputOptions[]): void;
+  onDidStartInstallingUpdate?(update: Reader.SoftwareUpdate): void;
+  onDidUpdateBatteryLevel?(result: Reader.BatteryLevel): void;
+};
 
+export type TerminalCallbacks = {
+  onDidReportUnexpectedReaderDisconnect?(error?: StripeError): void;
   onDidChangeConnectionStatus?(status: Reader.ConnectionStatus): void;
   onDidChangePaymentStatus?(status: PaymentStatus): void;
+};
 
+export type ReconnectionCallbacks = {
+  onDidFailReaderReconnect?(): void;
   onDidStartReaderReconnect?(): void;
   onDidSucceedReaderReconnect?(): void;
-  onDidFailReaderReconnect?(): void;
+};
 
-  onDidChangeOfflineStatus?(status: OfflineStatus): void;
+export type OfflineCallbacks = {
   onDidForwardPaymentIntent?(
     paymentIntent: PaymentIntent.Type,
     error: StripeError
   ): void;
   onDidForwardingFailure?(error?: StripeError): void;
+  onDidChangeOfflineStatus?(status: OfflineStatus): void;
+};
 
-  onDidDisconnect?(reason?: Reader.DisconnectReason): void;
+export type DiscoveryCallbacks = {
+  onFinishDiscoveringReaders?(error?: StripeError): void;
+  onUpdateDiscoveredReaders?(readers: Reader.Type[]): void;
+};
 
-  onDidUpdateBatteryLevel?(result: Reader.BatteryLevel): void;
-  onDidReportLowBatteryWarning?(): void;
-  onDidReportReaderEvent?(event: ReaderEvent): void;
-
+export type LocalMobileReaderCallbacks = {
   onDidAcceptTermsOfService?(): void;
 };
 


### PR DESCRIPTION
## Summary

Split useTerminal Callback into different group to give user a better sense 

## Motivation

Part of the request from https://bugs.bbpos.com/projects/SDK/issues/SDK-189
In general, we'd like to break useTerminal callback down into different types to give users a sense of when each callback is needed.

## Testing

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
