### PR TITLE
Fix getLocation api param limit wrong value

### DIFF
--- a/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
@@ -579,7 +579,7 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
         val listParameters = ListLocationsParameters.Builder().apply {
             endingBefore = params.getString("endingBefore")
             startingAfter = params.getString("startingAfter")
-            limit = getInt(params, "endingBefore")
+            limit = getInt(params, "limit")
         }
         terminal.listLocations(listParameters.build(), RNLocationListCallback(promise))
     }


### PR DESCRIPTION
## Summary

Fix getLocation api param limit wrong value

## Motivation

As describe in https://bugs.bbpos.com/browse/SDK-223
The limit key is accidentally assign wrong value

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
