### PR TITLE
Fix infinite loop location api

### DIFF
--- a/dev-app/src/screens/LocationListScreen.tsx
+++ b/dev-app/src/screens/LocationListScreen.tsx
@@ -24,7 +24,7 @@ export default function LocationListScreen() {
   const { params } = useRoute<RouteProp<RouteParamList, 'LocationList'>>();
 
   const { getLocations, loading } = useStripeTerminal();
-  const [list, setList] = useState<Location[]>([]);
+  const [list, setList] = useState<Location[]>(cachedLocations);
   const dummyLocations: Location[] = [
     { id: 'ABCD', displayName: 'Bad Location', livemode: false },
     {
@@ -35,17 +35,20 @@ export default function LocationListScreen() {
   ];
 
   useEffect(() => {
+    if (list != null && list.length != 0) {
+      setCachedLocations(list);
+    }
+  }, [list, setCachedLocations]);
+
+  useEffect(() => {
     async function init() {
       const { locations } = await getLocations({ limit: 20 });
       if (locations) {
         setList(locations);
-        setCachedLocations(locations);
-      } else {
-        setList(cachedLocations);
       }
     }
     init();
-  }, [getLocations, setCachedLocations, cachedLocations]);
+  }, [getLocations]);
 
   const renderItem = (item: Location) => (
     <ListItem


### PR DESCRIPTION
## Summary

Fix infinite loop location api

## Motivation

Using `useEffect` with multiple dependency might cause infinite loop as here. 
And also js is using `Object.is` to compare diff instead of the real content, so sometime what we think is the same isn't.
The solution is to break single `useEffect` into two for now to avoid nested update trigger loop.
Reference: https://bugs.bbpos.com/browse/SDK-219

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
