### PR TITLE
Add `getNativeSdkVersion` to get native sdk version

### DIFF
--- a/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
@@ -11,6 +11,7 @@ import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.UiThreadUtil
+import com.stripe.stripeterminal.BuildConfig
 import com.stripe.stripeterminal.Terminal
 import com.stripe.stripeterminal.TerminalApplicationDelegate.onCreate
 import com.stripe.stripeterminal.external.CollectData
@@ -1119,6 +1120,12 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
         localMobileUxConfigurationBuilder.darkMode(mapToDarkMode(params.getString("darkMode")))
 
         terminal.setLocalMobileUxConfiguration(localMobileUxConfigurationBuilder.build())
+    }
+
+    @ReactMethod
+    @Suppress("unused")
+    fun getNativeSdkVersion(promise: Promise) {
+        promise.resolve(BuildConfig.SDK_VERSION_NAME)
     }
 
     private fun String?.toLocalMobileColor(): LocalMobileUxConfiguration.Color {

--- a/ios/StripeTerminalReactNative.m
+++ b/ios/StripeTerminalReactNative.m
@@ -247,4 +247,9 @@ RCT_EXTERN_METHOD(
                   resolver: (RCTPromiseResolveBlock)resolve
                   rejecter: (RCTPromiseRejectBlock)reject
                   )
+
+RCT_EXTERN_METHOD(
+                  getNativeSdkVersion: (RCTPromiseResolveBlock)resolve
+                  rejecter: (RCTPromiseRejectBlock)reject
+                  )
 @end

--- a/ios/StripeTerminalReactNative.swift
+++ b/ios/StripeTerminalReactNative.swift
@@ -1390,6 +1390,11 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, BluetoothRe
         }
     }
 
+    @objc(getNativeSdkVersion:rejecter:)
+    func getNativeSdkVersion(resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+        resolve(SCPSDKVersion)
+    }
+
     func reader(_ reader: Reader, didReportAvailableUpdate update: ReaderSoftwareUpdate) {
         sendEvent(withName: ReactNativeConstants.REPORT_AVAILABLE_UPDATE.rawValue, body: ["result": Mappers.mapFromReaderSoftwareUpdate(update) ?? [:]])
     }

--- a/src/StripeTerminalSdk.tsx
+++ b/src/StripeTerminalSdk.tsx
@@ -175,6 +175,7 @@ export interface StripeTerminalSdkType {
   setLocalMobileUxConfiguration(params: LocalMobileUxConfiguration): Promise<{
     error?: StripeError;
   }>;
+  getNativeSdkVersion(): Promise<string>;
 }
 
 export default StripeTerminalReactNative as StripeTerminalSdkType;

--- a/src/__tests__/__snapshots__/functions.test.ts.snap
+++ b/src/__tests__/__snapshots__/functions.test.ts.snap
@@ -33,6 +33,7 @@ Object {
   "getConnectedReader": [Function],
   "getConnectionStatus": [Function],
   "getLocations": [Function],
+  "getNativeSdkVersion": [Function],
   "getOfflineStatus": [Function],
   "getPaymentStatus": [Function],
   "getReaderSettings": [Function],

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -970,3 +970,9 @@ export async function setLocalMobileUxConfiguration(
     }
   }, 'setLocalMobileUxConfiguration')();
 }
+
+export async function getNativeSdkVersion(): Promise<string> {
+  return Logger.traceSdkMethod(async () => {
+    return await StripeTerminalSdk.getNativeSdkVersion();
+  }, 'getNativeSdkVersion')();
+}

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -973,6 +973,10 @@ export async function setLocalMobileUxConfiguration(
 
 export async function getNativeSdkVersion(): Promise<string> {
   return Logger.traceSdkMethod(async () => {
-    return await StripeTerminalSdk.getNativeSdkVersion();
+    try {
+      return await StripeTerminalSdk.getNativeSdkVersion();
+    } catch (error) {
+      return '';
+    }
   }, 'getNativeSdkVersion')();
 }

--- a/src/hooks/__tests__/__snapshots__/useStripeTerminal.test.tsx.snap
+++ b/src/hooks/__tests__/__snapshots__/useStripeTerminal.test.tsx.snap
@@ -37,6 +37,7 @@ Object {
     "getConnectedReader": [Function],
     "getConnectionStatus": [Function],
     "getLocations": [Function],
+    "getNativeSdkVersion": [Function],
     "getOfflineStatus": [Function],
     "getPaymentStatus": [Function],
     "getReaderSettings": [Function],

--- a/src/hooks/useStripeTerminal.tsx
+++ b/src/hooks/useStripeTerminal.tsx
@@ -74,6 +74,7 @@ import {
   getConnectionStatus,
   getConnectedReader,
   setLocalMobileUxConfiguration,
+  getNativeSdkVersion,
 } from '../functions';
 import { StripeTerminalContext } from '../components/StripeTerminalContext';
 import { useListener } from './useListener';
@@ -1069,6 +1070,10 @@ export function useStripeTerminal(props?: Props) {
     [_isInitialized, setLoading]
   );
 
+  const _getNativeSdkVersion = useCallback(async () => {
+    return await getNativeSdkVersion();
+  }, []);
+
   return {
     initialize: _initialize,
     discoverReaders: _discoverReaders,
@@ -1115,6 +1120,7 @@ export function useStripeTerminal(props?: Props) {
     cancelReaderReconnection: _cancelReaderReconnection,
     supportsReadersOfType: _supportsReadersOfType,
     setLocalMobileUxConfiguration: _setLocalMobileUxConfiguration,
+    getNativeSdkVersion: _getNativeSdkVersion,
     emitter: emitter,
     discoveredReaders,
     connectedReader,


### PR DESCRIPTION
## Summary

Add `getNativeSdkVersion` to get native sdk version

## Motivation

Add `getNativeSdkVersion` function to reveal the embedded Android/iOS sdk version.
Reference: https://bugs.bbpos.com/browse/SDK-227

## Testing

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
