### PR TITLE
Update withStripeTerminal variable reference link

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ export default function PaymentScreen() {
 In case your app uses `React Class Components` you can use dedicated `withStripeTerminal` Higher-Order-Component.
 Please note that unlike the hooks approach, you need to use event emitter to listen on specific events that comes from SDK.
 
-[Here](https://github.com/stripe/stripe-terminal-react-native/blob/main/src/hooks/useStripeTerminal.tsx#L85-L109) you can find the list of available events to be used within the event emitter.
+[Here](https://github.com/stripe/stripe-terminal-react-native/blob/281df38/src/hooks/useStripeTerminal.tsx#L85-L109) you can find the list of available events to be used within the event emitter.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ export default function PaymentScreen() {
 In case your app uses `React Class Components` you can use dedicated `withStripeTerminal` Higher-Order-Component.
 Please note that unlike the hooks approach, you need to use event emitter to listen on specific events that comes from SDK.
 
-[Here](https://github.com/stripe/stripe-terminal-react-native/blob/main/src/hooks/useStripeTerminal.tsx#L51) you can find the list of available events to be used within the event emitter.
+[Here](https://github.com/stripe/stripe-terminal-react-native/blob/main/src/hooks/useStripeTerminal.tsx#L85-L109) you can find the list of available events to be used within the event emitter.
 
 Example:
 


### PR DESCRIPTION
## Summary

Update withStripeTerminal variable reference link

## Motivation

The line number in source code file is shifted since the code is rapidly evolved, update and also point to a range instead of single line for now.

The original reference should be: https://github.com/stripe/stripe-terminal-react-native/blame/a534b8f8efb42ec033c278c4058bcf8755d2abf2/src/hooks/useStripeTerminal.tsx#L51

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
