### PR TITLE
Bump ios sdk version to 3.8.3

### DIFF
--- a/dev-app/ios/Podfile.lock
+++ b/dev-app/ios/Podfile.lock
@@ -440,11 +440,11 @@ PODS:
   - SocketRocket (0.6.1)
   - stripe-terminal-react-native (0.0.1-beta.20):
     - React-Core
-    - StripeTerminal (~> 3.8.1)
+    - StripeTerminal (~> 3.8.3)
   - stripe-terminal-react-native/Tests (0.0.1-beta.20):
     - React-Core
-    - StripeTerminal (~> 3.8.1)
-  - StripeTerminal (3.8.1)
+    - StripeTerminal (~> 3.8.3)
+  - StripeTerminal (3.8.3)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -644,8 +644,8 @@ SPEC CHECKSUMS:
   RNGestureHandler: 32a01c29ecc9bb0b5bf7bc0a33547f61b4dc2741
   RNScreens: 3c2d122f5e08c192e254c510b212306da97d2581
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  stripe-terminal-react-native: 88b439710351cde325e1916c862878eb7b1f78ed
-  StripeTerminal: 79618e96297bf13eee53177c6888abb0b99c5958
+  stripe-terminal-react-native: f7f4a9333d9f1f5eebf1bd0f9455ddeae8b4f971
+  StripeTerminal: 1982b8395d3a45d887a6db0ff75aa3df8be58dcb
   Yoga: 4c3aa327e4a6a23eeacd71f61c81df1bcdf677d5
 
 PODFILE CHECKSUM: e42df060dac549df682e535ef903a0f36c3e799c

--- a/stripe-terminal-react-native.podspec
+++ b/stripe-terminal-react-native.podspec
@@ -21,5 +21,5 @@ Pod::Spec.new do |s|
   end
 
   s.dependency 'React-Core'
-  s.dependency 'StripeTerminal', '~> 3.8.1'
+  s.dependency 'StripeTerminal', '~> 3.8.3'
 end


### PR DESCRIPTION
## Summary

https://bugs.bbpos.com/browse/SDK-218
Bump iOS SDK version to 3.8.3

## Motivation

Upgrade the native iOS SDKs to the latest.

## Testing

Testing via apply change in https://github.com/stripe/stripe-terminal-react-native/pull/790

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
