### PR TITLE
Expose RN SDK version

### DIFF
--- a/src/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/__tests__/__snapshots__/index.test.tsx.snap
@@ -80,6 +80,7 @@ Object {
   "UPDATE_DISCOVERED_READERS": "UPDATE_DISCOVERED_READERS",
   "UseStripeTerminalProps": undefined,
   "WithStripeTerminalProps": undefined,
+  "getSdkVersion": [Function],
   "requestNeededAndroidPermissions": [Function],
   "useStripeTerminal": [Function],
   "withStripeTerminal": [Function],

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,7 +2,9 @@ export * from './types';
 export * from './StripeTerminalSdk';
 import * as PackageJson from '../package.json';
 
-export const SDK_VERSION = PackageJson.version;
+export const getSdkVersion = () => {
+  return PackageJson.version;
+};
 
 // hooks
 export {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,8 @@
 export * from './types';
 export * from './StripeTerminalSdk';
+import * as PackageJson from '../package.json';
+
+export const SDK_VERSION = PackageJson.version;
 
 // hooks
 export {


### PR DESCRIPTION
## Summary

Expose RN SDK version

## Motivation

We should expose RN SDK version so user will have a better way to check which version they integrate.
https://bugs.bbpos.com/browse/SDK-228

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
