### PR TITLE
Enable backend PI creation toggle

### DIFF
--- a/dev-app/src/App.tsx
+++ b/dev-app/src/App.tsx
@@ -74,7 +74,6 @@ export type RouteParamList = {
   CollectCardPayment: {
     simulated: boolean;
     discoveryMethod: Reader.DiscoveryMethod;
-    deviceType: Reader.DeviceType;
   };
   RefundPayment: {
     simulated: boolean;

--- a/dev-app/src/screens/CollectCardPaymentScreen.tsx
+++ b/dev-app/src/screens/CollectCardPaymentScreen.tsx
@@ -86,6 +86,7 @@ export default function CollectCardPaymentScreen() {
   });
   const [testCardNumber, setTestCardNumber] = useState('4242424242424242');
   const [enableInterac, setEnableInterac] = useState(false);
+  const [enableBackendPI, setEnableBackendPI] = useState(false);
   const [enableConnect, setEnableConnect] = useState(false);
   const [skipTipping, setSkipTipping] = useState(false);
   const [enableUpdatePaymentIntent, setEnableUpdatePaymentIntent] =
@@ -100,7 +101,7 @@ export default function CollectCardPaymentScreen() {
   const [amountSurcharge, setAmountSurcharge] = useState('');
   const { params } =
     useRoute<RouteProp<RouteParamList, 'CollectCardPayment'>>();
-  const { simulated, discoveryMethod, deviceType } = params;
+  const { simulated, discoveryMethod } = params;
   const { addLogs, clearLogs, setCancel } = useContext(LogContext);
   const navigation = useNavigation();
 
@@ -181,7 +182,7 @@ export default function CollectCardPaymentScreen() {
     let paymentIntent: PaymentIntent.Type | undefined;
     let paymentIntentError: StripeError<CommonError> | undefined;
 
-    if (deviceType === 'verifoneP400') {
+    if (enableBackendPI) {
       const resp = await api.createPaymentIntent({
         amount: Number(inputValues.amount),
         currency: inputValues.currency,
@@ -638,6 +639,19 @@ export default function CollectCardPaymentScreen() {
               testID="enable-interac"
               value={enableInterac}
               onValueChange={(value) => setEnableInterac(value)}
+            />
+          }
+        />
+      </List>
+
+      <List bolded={false} topSpacing={false} title="BACKEND PI">
+        <ListItem
+          title="Create PI on the backend"
+          rightElement={
+            <Switch
+              testID="enable-backend-pi"
+              value={enableBackendPI}
+              onValueChange={(value) => setEnableBackendPI(value)}
             />
           }
         />

--- a/dev-app/src/screens/HomeScreen.tsx
+++ b/dev-app/src/screens/HomeScreen.tsx
@@ -187,7 +187,6 @@ export default function HomeScreen() {
             navigation.navigate('CollectCardPaymentScreen', {
               simulated,
               discoveryMethod,
-              deviceType,
             });
           }}
         />


### PR DESCRIPTION
## Summary
We default to creating PIs through the SDK when using dev-app. This allows the user to choose whether the PI should be created through the SDK or backend.
<!-- Simple summary of what was changed. -->

## Motivation
Testing improvements 
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
