### PR TITLE
Add ACCEPT_TERMS_OF_SERVICE event in StripeTerminalProvider

### DIFF
--- a/src/components/StripeTerminalProvider.tsx
+++ b/src/components/StripeTerminalProvider.tsx
@@ -39,6 +39,7 @@ const {
   UPDATE_BATTERY_LEVEL,
   REPORT_LOW_BATTERY_WARNING,
   REPORT_READER_EVENT,
+  ACCEPT_TERMS_OF_SERVICE,
 } = NativeModules.StripeTerminalReactNative.getConstants();
 
 const emitter = new EventEmitter();
@@ -269,6 +270,11 @@ export function StripeTerminalProvider({
     [log]
   );
 
+  const didAcceptTermsOfService = useCallback(() => {
+    log('didAcceptTermsOfService');
+    emitter?.emit(ACCEPT_TERMS_OF_SERVICE);
+  }, [log]);
+
   useListener(REPORT_AVAILABLE_UPDATE, didReportAvailableUpdate);
   useListener(START_INSTALLING_UPDATE, didStartInstallingUpdate);
   useListener(REPORT_UPDATE_PROGRESS, didReportReaderSoftwareUpdateProgress);
@@ -298,6 +304,7 @@ export function StripeTerminalProvider({
   useListener(UPDATE_BATTERY_LEVEL, didUpdateBatteryLevel);
   useListener(REPORT_LOW_BATTERY_WARNING, didReportLowBatteryWarning);
   useListener(REPORT_READER_EVENT, didReportReaderEvent);
+  useListener(ACCEPT_TERMS_OF_SERVICE, didAcceptTermsOfService);
 
   const tokenProviderHandler = async () => {
     try {


### PR DESCRIPTION
## Summary

Add ACCEPT_TERMS_OF_SERVICE event in StripeTerminalProvider

## Motivation

To align existing design, we'll add ACCEPT_TERMS_OF_SERVICE to StripeTerminalProvider as well.

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
