### PR TITLE
By pass user cancel error in DiscoverReaderScreen page

### DIFF
--- a/dev-app/src/screens/DiscoverReadersScreen.tsx
+++ b/dev-app/src/screens/DiscoverReadersScreen.tsx
@@ -67,10 +67,12 @@ export default function DiscoverReadersScreen() {
   } = useStripeTerminal({
     onFinishDiscoveringReaders: (finishError) => {
       if (finishError) {
-        console.error(
-          'Discover readers error',
-          `${finishError.code}, ${finishError.message}`
-        );
+        if (shouldShowDiscoverError(finishError)) {
+          console.error(
+            'Discover readers error',
+            `${finishError.code}, ${finishError.message}`
+          );
+        }
         if (navigation.canGoBack()) {
           navigation.goBack();
         }
@@ -165,7 +167,9 @@ export default function DiscoverReadersScreen() {
 
     if (discoverReadersError) {
       const { code, message } = discoverReadersError;
-      Alert.alert('Discover readers error: ', `${code}, ${message}`);
+      if (shouldShowDiscoverError(discoverReadersError)) {
+        Alert.alert('Discover readers error: ', `${code}, ${message}`);
+      }
       if (navigation.canGoBack()) {
         navigation.goBack();
       }
@@ -534,4 +538,8 @@ function mapToPlanDisplayName(plan: string) {
     default:
       return '';
   }
+}
+
+function shouldShowDiscoverError(error: StripeError) {
+  return error.code.toString() != 'USER_ERROR.CANCELED';
 }


### PR DESCRIPTION
## Summary

By pass user cancel error in DiscoverReaderScreen page

## Motivation

https://jira.corp.stripe.com/browse/TERMINAL-40457
User cancel event in discover reader page shouldn't treat as error and it didn't provide value in testing. So we decided to by pass it instead.

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
