### PR TITLE
Add ios error code to skip display error when discovering

### DIFF
--- a/dev-app/src/screens/DiscoverReadersScreen.tsx
+++ b/dev-app/src/screens/DiscoverReadersScreen.tsx
@@ -541,5 +541,10 @@ function mapToPlanDisplayName(plan: string) {
 }
 
 function shouldShowDiscoverError(error: StripeError) {
-  return error.code.toString() != 'USER_ERROR.CANCELED';
+  if (Platform.OS === 'android') {
+    return error.code.toString() != 'USER_ERROR.CANCELED';
+  } else if (Platform.OS === 'ios') {
+    return error.code.toString() != 'Canceled';
+  }
+  return true;
 }


### PR DESCRIPTION
## Summary

Add each cancel error code for each platform

## Motivation

Part of https://github.com/stripe/stripe-terminal-react-native/pull/831 work.
Since the error code is not sync in Android/iOS, we have to handle separately.
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
