### PR TITLE
Enable toggle for local mobile discovery method

### DIFF
--- a/dev-app/Gemfile
+++ b/dev-app/Gemfile
@@ -3,3 +3,7 @@ source 'https://rubygems.org'
 ruby '3.2.3'
 gem 'cocoapods', '~> 1.15.2'
 gem 'activesupport', '>= 6.1.7.3', '< 7.1.0'
+
+# https://discuss.bitrise.io/t/sandbox-file-write-create-errors-after-the-xcodeproj-gem-was-auto-updated-to-1-26-0/24643
+# might remove after upgrade to rn 0.76
+gem 'xcodeproj', '1.25.1'

--- a/dev-app/src/screens/DiscoverReadersScreen.tsx
+++ b/dev-app/src/screens/DiscoverReadersScreen.tsx
@@ -364,6 +364,7 @@ export default function DiscoverReadersScreen() {
       {!simulated &&
         (discoveryMethod === 'bluetoothScan' ||
           discoveryMethod === 'usb' ||
+          discoveryMethod === 'localMobile' ||
           discoveryMethod === 'bluetoothProximity') && (
           <List
             bolded={false}


### PR DESCRIPTION
## Summary

Enable toggle for local mobile discovery method

## Motivation

iOS support reconnect for local mobile discovery method, so we should enable this toggle in RN dev-app for testing.

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
