### PR TITLE
Update to M2 CI

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -277,7 +277,7 @@ workflows:
 meta:
   bitrise.io:
     stack: osx-xcode-15.2.x
-    machine_type_id: g2-m1.8core
+    machine_type_id: g2.mac.large
 app:
   envs:
     - opts:


### PR DESCRIPTION
## Summary
Update to M2 builders.

## Motivation
M1 builders are deprecated.

## Testing
CI
