### PR TITLE
Update collectData response to return as a CollectDataResultType

### DIFF
--- a/src/functions.ts
+++ b/src/functions.ts
@@ -905,7 +905,9 @@ export async function collectData(
   return Logger.traceSdkMethod(async () => {
     try {
       const response = await StripeTerminalSdk.collectData(params);
-      return response;
+      return {
+        collectedData: response
+      };
     } catch (error) {
       return {
         error: error as any,

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -906,7 +906,7 @@ export async function collectData(
     try {
       const response = await StripeTerminalSdk.collectData(params);
       return {
-        collectedData: response
+        collectedData: response,
       };
     } catch (error) {
       return {


### PR DESCRIPTION
## Summary

Fix `Terminal.collectData` to return the collected data in the correct `CollectDataResultType` format. The previous solution was directly returning the collected data object, when it should be returning it nested inside a `collectedData` key as defined in `CollectDataResultType`.

cc-ing @EricLin-BBpos who worked on the initial PR: #765 

## Motivation

Internal ticket filed by QA: https://jira.corp.stripe.com/browse/TERMINAL-41707

## Testing

Tested manually with the dev-app. Ran `npx react-native run-ios --device`
<img src=https://github.com/user-attachments/assets/2d742d0b-e30d-4500-a2c2-43d0db667ab7 height=500/> <img src=https://github.com/user-attachments/assets/1f3b3298-e439-4524-bfd6-734c8d5cd2cc height=500/>

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
