### PR TITLE
Add missing error stringValue in iOS

### DIFF
--- a/ios/Errors.swift
+++ b/ios/Errors.swift
@@ -254,6 +254,44 @@ extension ErrorCode.Code {
             return "ConnectionTokenProviderTimedOut"
         case .surchargingNotAvailable:
             return "SurchargingNotAvailable"
+        case .invalidRequiredParameterOnBehalfOf:
+            return "InvalidRequiredParameterOnBehalfOf"
+        case .requestDynamicCurrencyConversionRequiresUpdatePaymentIntent:
+            return "RequestDynamicCurrencyConversionRequiresUpdatePaymentIntent"
+        case .dynamicCurrencyConversionNotAvailable:
+            return "DynamicCurrencyConversionNotAvailable"
+        case .surchargeNoticeRequiresUpdatePaymentIntent:
+            return "SurchargeNoticeRequiresUpdatePaymentIntent"
+        case .surchargeUnavailableWithDynamicCurrencyConversion:
+            return "SurchargeUnavailableWithDynamicCurrencyConversion"
+        case .collectInputsInvalidParameter:
+            return "CollectInputsInvalidParameter"
+        case .collectInputsUnsupported:
+            return "CollectInputsUnsupported"
+        case .readerConnectionOfflineNeedsUpdate:
+            return "ReaderConnectionOfflineNeedsUpdate"
+        case .readerConnectionOfflinePairingUnseenDisabled:
+            return "ReaderConnectionOfflinePairingUnseenDisabled"
+        case .collectInputsTimedOut:
+            return "CollectInputsTimedOut"
+        case .usbDiscoveryTimedOut:
+            return "UsbDiscoveryTimedOut"
+        case .appleBuiltInReaderAccountDeactivated:
+            return "AppleBuiltInReaderAccountDeactivated"
+        case .readerMissingEncryptionKeys:
+            return "ReaderMissingEncryptionKeys"
+        case .usbDisconnected:
+            return "UsbDisconnected"
+        case .encryptionKeyFailure:
+            return "EncryptionKeyFailure"
+        case .encryptionKeyStillInitializing:
+            return "EncryptionKeyStillInitializing"
+        case .collectInputsApplicationError:
+            return "CollectInputsApplicationError"
+        case .onlinePinNotSupportedOffline:
+            return "OnlinePinNotSupportedOffline"
+        case .offlineTestCardInLivemode:
+            return "OfflineTestCardInLivemode"
         @unknown default:
             return "Unknown"
         }


### PR DESCRIPTION
## Summary

Add missing error string value in iOS

## Motivation

There are several iOS errors not reflect to RN sdk user.
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [ ] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
