### PR TITLE
Fix surcharge param passing in dev-app and iOS bridge

### DIFF
--- a/dev-app/src/screens/CollectCardPaymentScreen.tsx
+++ b/dev-app/src/screens/CollectCardPaymentScreen.tsx
@@ -352,7 +352,7 @@ export default function CollectCardPaymentScreen() {
       updatePaymentIntent: enableUpdatePaymentIntent,
       enableCustomerCancellation: enableCustomerCancellation,
       requestDynamicCurrencyConversion: requestDcc,
-      surchargeNotice: surchargeNotice,
+      surchargeNotice: surchargeNotice ? surchargeNotice : undefined,
     });
 
     if (error) {

--- a/ios/StripeTerminalReactNative.swift
+++ b/ios/StripeTerminalReactNative.swift
@@ -543,10 +543,7 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, BluetoothRe
             .setUpdatePaymentIntent(updatePaymentIntent)
             .setEnableCustomerCancellation(enableCustomerCancellation)
             .setRequestDynamicCurrencyConversion(requestDynamicCurrencyConversion)
-
-        if updatePaymentIntent, let surchargeNoticeValue = surchargeNotice {
-            collectConfigBuilder.setSurchargeNotice(surchargeNoticeValue)
-        }
+            .setSurchargeNotice(surchargeNotice)
 
         if let eligibleAmount = params["tipEligibleAmount"] as? Int {
             do {


### PR DESCRIPTION
## Summary
We were passing an empty string to collectPaymentIntent for `surchargeNotice` which is causing the SDK to think we are trying to set it every time. This PR fixes the dev-app so we don't pass a value if it's `false` by JS standards. It also removed the `updatePaymentIntent` check to set `surchageNotice` as that's handled by the native SDK and we should just pass whatever we received from the user blindly.
<!-- Simple summary of what was changed. -->

## Motivation

<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
