### PR TITLE
[4.1.0] Add support for return_url and Affirm

### DIFF
--- a/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
@@ -9,6 +9,7 @@ import com.facebook.react.bridge.WritableNativeArray
 import com.stripe.stripeterminal.external.CollectInputs
 import com.stripe.stripeterminal.external.OfflineMode
 import com.stripe.stripeterminal.external.models.Address
+import com.stripe.stripeterminal.external.models.AffirmDetails
 import com.stripe.stripeterminal.external.models.AllowRedisplay
 import com.stripe.stripeterminal.external.models.AmountDetails
 import com.stripe.stripeterminal.external.models.BatteryStatus
@@ -586,6 +587,10 @@ internal fun mapFromPaymentMethod(paymentMethod: PaymentMethod?): ReadableMap? =
                 "wechatPayDetails",
                 mapFromWechatPayDetails(it.wechatPayDetails)
             )
+            putMap(
+                "affirmDetails",
+                mapFromAffirmDetails(it.affirmDetails)
+            )
             putString("customer", it.customer)
             putString("id", it.id)
             putString("type", mapFromPaymentMethodDetailsType(it.type))
@@ -619,6 +624,10 @@ private fun mapFromPaymentMethodDetails(paymentMethodDetails: PaymentMethodDetai
             "wechatPayDetails",
             mapFromWechatPayDetails(paymentMethodDetails?.wechatPayDetails)
         )
+        putMap(
+            "affirmDetails",
+            mapFromAffirmDetails(paymentMethodDetails?.affirmDetails)
+        )
         putString("type", mapFromPaymentMethodDetailsType(paymentMethodDetails?.type))
     }
 
@@ -628,6 +637,7 @@ internal fun mapFromPaymentMethodDetailsType(type: PaymentMethodType?): String {
         PaymentMethodType.CARD_PRESENT -> "cardPresent"
         PaymentMethodType.INTERAC_PRESENT -> "interacPresent"
         PaymentMethodType.WECHAT_PAY -> "wechatPay"
+        PaymentMethodType.AFFIRM -> "affirm"
         else -> "unknown"
     }
 }
@@ -662,6 +672,15 @@ private fun mapFromCardPresentDetails(cardPresentDetails: CardPresentDetails?): 
 
 private fun mapFromWechatPayDetails(wechatPayDetails: WechatPayDetails?): ReadableMap? =
     wechatPayDetails?.let {
+        nativeMapOf {
+            putString("location", it.location)
+            putString("reader", it.reader)
+            putString("transactionId", it.transactionId)
+        }
+    }
+
+private fun mapFromAffirmDetails(affirmDetails: AffirmDetails?): ReadableMap? =
+    affirmDetails?.let {
         nativeMapOf {
             putString("location", it.location)
             putString("reader", it.reader)

--- a/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
@@ -650,6 +650,10 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
             val amountSurcharge = getInt(params, "amountSurcharge")?.toLong()
             configBuilder.amountSurcharge(amountSurcharge)
         }
+        if (params.hasKey("returnUrl")) {
+            val returnUrl = params.getString("returnUrl")
+            configBuilder.setReturnUrl(returnUrl)
+        }
         val config = configBuilder.build()
 
         confirmPaymentIntentCancelable = terminal.confirmPaymentIntent(

--- a/dev-app/src/screens/CollectCardPaymentScreen.tsx
+++ b/dev-app/src/screens/CollectCardPaymentScreen.tsx
@@ -116,6 +116,7 @@ export default function CollectCardPaymentScreen() {
   const [surchargeNotice, setSurchargeNotice] = useState('');
   const [tipEligibleAmount, setTipEligibleAmount] = useState('');
   const [amountSurcharge, setAmountSurcharge] = useState('');
+  const [returnUrl, setReturnUrl] = useState('');
   const paymentMethodTypes = PAYMENT_METHOD_TYPES;
   const [enabledPaymentMethodTypes, setEnabledPaymentMethodTypes] = useState(
     DEFAULT_ENABLED_PAYMENT_METHOD_TYPES
@@ -466,6 +467,7 @@ export default function CollectCardPaymentScreen() {
     const { paymentIntent, error } = await confirmPaymentIntent({
       paymentIntent: collectedPaymentIntent,
       amountSurcharge: amountSurcharge ? Number(amountSurcharge) : undefined,
+      returnUrl: returnUrl.trim() ? returnUrl : undefined,
     });
 
     if (error) {
@@ -882,6 +884,18 @@ export default function CollectCardPaymentScreen() {
             value={amountSurcharge}
             onChangeText={(value: string) => setAmountSurcharge(value)}
             placeholder="Amount Surcharge"
+          />
+        </List>
+
+        <List bolded={false} topSpacing={false} title="RETURN URL">
+          <TextInput
+            testID="Return URL"
+            keyboardType="default"
+            style={styles.input}
+            value={returnUrl}
+            onChangeText={(value: string) => setReturnUrl(value)}
+            autoCorrect={false}
+            autoCapitalize={'none'}
           />
         </List>
 

--- a/ios/Mappers.swift
+++ b/ios/Mappers.swift
@@ -523,6 +523,15 @@ class Mappers {
         return result
     }
 
+    class func mapFromAffirm(_ affirm: AffirmDetails) -> NSDictionary {
+        let result: NSDictionary = [
+            "location": affirm.location ?? NSNull(),
+            "reader": affirm.reader ?? NSNull(),
+            "transactionId": affirm.transactionId ?? NSNull(),
+        ]
+        return result
+    }
+
     class func mapFromOfflineDetails(_ offlineDetails: OfflineDetails) -> NSDictionary {
         var offlineCardPresentDetails: NSDictionary?
         if let cardPresentDetails = offlineDetails.cardPresentDetails {
@@ -640,6 +649,7 @@ class Mappers {
         case PaymentMethodType.cardPresent: return "cardPresent"
         case PaymentMethodType.interacPresent: return "interacPresent"
         case PaymentMethodType.wechatPay: return "wechatPay"
+        case PaymentMethodType.affirm: return "affirm"
         default: return "unknown"
         }
     }
@@ -657,12 +667,17 @@ class Mappers {
         if let wechatPay = paymentMethodDetails.wechatPay{
             wechatPayMapped = mapFromWechatPay(wechatPay)
         }
+        var affirmMapped: NSDictionary?
+        if let affirm = paymentMethodDetails.affirm{
+            affirmMapped = mapFromAffirm(affirm)
+        }
 
         let result: NSDictionary = [
             "type": mapFromPaymentMethodDetailsType(paymentMethodDetails.type),
             "cardPresentDetails": cardPresentMapped ?? NSNull(),
             "interacPresentDetails": interacPresentMapped ?? NSNull(),
             "wechatPayDetails": wechatPayMapped ?? NSNull(),
+            "affirmDetails": affirmMapped ?? NSNull(),
         ]
         return result
     }
@@ -723,11 +738,16 @@ class Mappers {
         if let wechatPay = paymentMethod.wechatPay{
             wechatPayMapped = mapFromWechatPay(wechatPay)
         }
+        var affirmMapped: NSDictionary?
+        if let affirm = paymentMethod.affirm{
+            affirmMapped = mapFromAffirm(affirm)
+        }
 
         let result: NSDictionary = [
             "cardPresentDetails": cardPresentMapped ?? NSNull(),
             "interacPresentDetails": interacPresentMapped ?? NSNull(),
             "wechatPayDetails": wechatPayMapped ?? NSNull(),
+            "affirmDetails": affirmMapped ?? NSNull(),
             "customer": paymentMethod.customer ?? NSNull(),
             "id": paymentMethod.stripeId,
             "type": mapFromPaymentMethodDetailsType(paymentMethod.type),
@@ -943,10 +963,11 @@ class Mappers {
         case "card_present": return .cardPresent
         case "interac_present": return .interacPresent
         case "wechat_pay": return .wechatPay
+        case "affirm": return .affirm
         default: return .unknown
         }
     }
-    
+
 }
 
 extension UInt {

--- a/ios/StripeTerminalReactNative.swift
+++ b/ios/StripeTerminalReactNative.swift
@@ -28,7 +28,7 @@ enum ReactNativeConstants: String, CaseIterable {
 
 @objc(StripeTerminalReactNative)
 class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, MobileReaderDelegate, TerminalDelegate, OfflineDelegate, InternetReaderDelegate, TapToPayReaderDelegate, ReaderDelegate {
-    
+
     var discoveredReadersList: [Reader]? = nil
     var paymentIntents: [AnyHashable : PaymentIntent] = [:]
     var setupIntents: [AnyHashable : SetupIntent] = [:]
@@ -301,7 +301,7 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, MobileReade
         let onBehalfOf: String? = params["onBehalfOf"] as? String
         let merchantDisplayName: String? = params["merchantDisplayName"] as? String
         let tosAcceptancePermitted: Bool = params["tosAcceptancePermitted"] as? Bool ?? true
-        
+
         let connectionConfig: ConnectionConfiguration
         do {
             connectionConfig = try getConnectionConfig(
@@ -328,7 +328,7 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, MobileReade
             }
         }
     }
-    
+
     private func getConnectionConfig(
         selectedReader: Reader,
         locationId: String?,
@@ -669,9 +669,14 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, MobileReade
         }
 
         let amountSurcharge = params["amountSurcharge"] as? NSNumber
+        let returnUrl = params["returnUrl"] as? String
+
         let confirmConfigBuilder = ConfirmConfigurationBuilder()
         if let amountSurchargeValue = amountSurcharge {
             confirmConfigBuilder.setAmountSurcharge(UInt(truncating: amountSurchargeValue))
+        }
+        if let returnUrlValue = returnUrl {
+            confirmConfigBuilder.setReturnUrl(returnUrlValue)
         }
 
         let confirmConfig: ConfirmConfiguration

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -152,7 +152,8 @@ export type PaymentMethodType =
   | 'cardPresent'
   | 'interacPresent'
   | 'card'
-  | 'wechatPay';
+  | 'wechatPay'
+  | 'affirm';
 
 export interface Charge {
   id: string;
@@ -206,6 +207,7 @@ export type CollectPaymentMethodParams = {
 export type ConfirmPaymentMethodParams = {
   paymentIntent: PaymentIntent.Type;
   amountSurcharge?: number;
+  returnUrl?: string;
 };
 
 export type CancelPaymentMethodParams = {
@@ -313,6 +315,12 @@ export type WechatPayDetails = {
   transactionId?: string;
 };
 
+export type AffirmDetails = {
+  location?: string;
+  reader?: string;
+  transactionId?: string;
+};
+
 export type ReceiptDetails = {
   accountType: string;
   applicationCryptogram: string;
@@ -334,6 +342,7 @@ export type PaymentMethodDetails = {
   cardPresentDetails?: CardPresentDetails;
   interacPresentDetails?: CardPresentDetails;
   wechatPayDetails?: WechatPayDetails;
+  affirmDetails?: AffirmDetails;
 };
 
 export type ConfirmRefundResultType = {
@@ -409,6 +418,7 @@ export namespace PaymentMethod {
     interacPresentDetails: CardPresentDetails;
     cardPresentDetails: CardPresentDetails;
     wechatPayDetails: WechatPayDetails;
+    affirmDetails: AffirmDetails;
     metadata?: Record<string, string>;
   };
 }


### PR DESCRIPTION
## Summary
- Add support for Affirm PaymentMethodType
- Add support for passing return_url in ConfirmConfiguration
- Update iOS pods for hermes engine

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
