### PR TITLE
Added Tap to Pay Education View (iOS 18+ only)

### DIFF
--- a/ios/StripeTerminalReactNative.m
+++ b/ios/StripeTerminalReactNative.m
@@ -257,8 +257,7 @@ RCT_EXTERN_METHOD(
                   rejecter: (RCTPromiseRejectBlock)reject
                   )
 
-RCT_EXTERN_METHOD(promptTapToPayEducationView:(NSDictionary *)params
-                  resolver:(RCTPromiseResolveBlock)resolve
-                  rejecter:(RCTPromiseRejectBlock)reject)
-
+RCT_EXTERN_METHOD(promptTapToPayEducationView:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject
+                 )
 @end

--- a/ios/StripeTerminalReactNative.m
+++ b/ios/StripeTerminalReactNative.m
@@ -256,4 +256,9 @@ RCT_EXTERN_METHOD(
                   getNativeSdkVersion: (RCTPromiseResolveBlock)resolve
                   rejecter: (RCTPromiseRejectBlock)reject
                   )
+
+RCT_EXTERN_METHOD(promptTapToPayEducationView:(NSDictionary *)params
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
 @end

--- a/ios/StripeTerminalReactNative.swift
+++ b/ios/StripeTerminalReactNative.swift
@@ -1408,8 +1408,8 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, MobileReade
         resolve(SCPSDKVersion)
     }
 
-    @objc(promptTapToPayEducationView:resolver:rejecter:)
-    func promptTapToPayEducationView(params: NSDictionary, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
+    @objc(promptTapToPayEducationView:rejecter:)
+    func promptTapToPayEducationView(resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) {
         if #available(iOS 18.0, *) {
             guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else {
                 reject("ERR_NO_WINDOW_SCENE", "No available window scene", nil)

--- a/src/StripeTerminalSdk.tsx
+++ b/src/StripeTerminalSdk.tsx
@@ -49,6 +49,11 @@ interface InternalInitParams extends InitParams {
   reactNativeVersion: string;
 }
 
+interface PromptTapToPayEducationResult {
+  status: string;
+  message: string;
+}
+
 export interface StripeTerminalSdkType {
   // Initialize StripeTerminalSdk native module
   initialize(params: InternalInitParams): InitializeResultNativeType;
@@ -168,6 +173,7 @@ export interface StripeTerminalSdkType {
     error?: StripeError;
   }>;
   getNativeSdkVersion(): Promise<string>;
+  promptTapToPayEducationView(): Promise<PromptTapToPayEducationResult>;
 }
 
 export default StripeTerminalReactNative as StripeTerminalSdkType;

--- a/src/StripeTerminalSdk.tsx
+++ b/src/StripeTerminalSdk.tsx
@@ -36,6 +36,7 @@ import type {
   CollectDataResultType,
   TapToPayUxConfiguration,
   ConnectReaderParams,
+  PromptTapToPayEducationResult,
 } from './types';
 
 const { StripeTerminalReactNative } = NativeModules;
@@ -47,11 +48,6 @@ type InitializeResultNativeType = Promise<{
 
 interface InternalInitParams extends InitParams {
   reactNativeVersion: string;
-}
-
-interface PromptTapToPayEducationResult {
-  status: string;
-  message: string;
 }
 
 export interface StripeTerminalSdkType {

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -40,6 +40,8 @@ import type {
 } from './types';
 import { CommonError } from './types';
 import { Platform } from 'react-native';
+import { useCallback } from 'react';
+import StripeTerminalReactNative from './StripeTerminalSdk';
 
 export async function initialize(
   params: InitParams
@@ -918,4 +920,31 @@ export async function getNativeSdkVersion(): Promise<string> {
       return '';
     }
   }, 'getNativeSdkVersion')();
+}
+
+export function useTapToPayEducationView(props) {
+  const { onTapToPayEducationViewSuccess, onTapToPayEducationViewError } =
+    props || {};
+
+  const promptTapToPayEducationView = useCallback(async () => {
+    try {
+      const response =
+        await StripeTerminalReactNative.promptTapToPayEducationView();
+
+      if (onTapToPayEducationViewSuccess) {
+        onTapToPayEducationViewSuccess(response);
+      }
+
+      return response;
+    } catch (error) {
+      if (onTapToPayEducationViewError) {
+        onTapToPayEducationViewError(error);
+      }
+
+      console.error('Failed to show Tap to Pay Education View', error);
+      throw error;
+    }
+  }, [onTapToPayEducationViewSuccess, onTapToPayEducationViewError]);
+
+  return { promptTapToPayEducationView };
 }

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -37,10 +37,10 @@ import type {
   CollectDataResultType,
   TapToPayUxConfiguration,
   ConnectReaderParams,
+  PromptTapToPayEducationResult,
 } from './types';
 import { CommonError } from './types';
 import { Platform } from 'react-native';
-import { useCallback } from 'react';
 import StripeTerminalReactNative from './StripeTerminalSdk';
 
 export async function initialize(
@@ -922,29 +922,11 @@ export async function getNativeSdkVersion(): Promise<string> {
   }, 'getNativeSdkVersion')();
 }
 
-export function useTapToPayEducationView(props) {
-  const { onTapToPayEducationViewSuccess, onTapToPayEducationViewError } =
-    props || {};
-
-  const promptTapToPayEducationView = useCallback(async () => {
-    try {
-      const response =
-        await StripeTerminalReactNative.promptTapToPayEducationView();
-
-      if (onTapToPayEducationViewSuccess) {
-        onTapToPayEducationViewSuccess(response);
-      }
-
-      return response;
-    } catch (error) {
-      if (onTapToPayEducationViewError) {
-        onTapToPayEducationViewError(error);
-      }
-
-      console.error('Failed to show Tap to Pay Education View', error);
-      throw error;
-    }
-  }, [onTapToPayEducationViewSuccess, onTapToPayEducationViewError]);
-
-  return { promptTapToPayEducationView };
+export function promptTapToPayEducationView(): Promise<PromptTapToPayEducationResult> {
+  try {
+    const response = StripeTerminalReactNative.promptTapToPayEducationView();
+    return response;
+  } catch (error) {
+    throw error;
+  }
 }

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -214,9 +214,8 @@ export async function createSetupIntent(
 ): Promise<SetupIntentResultType> {
   return Logger.traceSdkMethod(async (innerParams) => {
     try {
-      const { error, setupIntent } = await StripeTerminalSdk.createSetupIntent(
-        innerParams
-      );
+      const { error, setupIntent } =
+        await StripeTerminalSdk.createSetupIntent(innerParams);
 
       if (error) {
         return {
@@ -586,9 +585,8 @@ export async function collectRefundPaymentMethod(
 }> {
   return Logger.traceSdkMethod(async (innerParams) => {
     try {
-      const { error } = await StripeTerminalSdk.collectRefundPaymentMethod(
-        innerParams
-      );
+      const { error } =
+        await StripeTerminalSdk.collectRefundPaymentMethod(innerParams);
       return {
         error,
       };
@@ -874,9 +872,8 @@ export async function supportsReadersOfType(
 ): Promise<Reader.ReaderSupportResult> {
   return Logger.traceSdkMethod(async () => {
     try {
-      const supportReaderResult = await StripeTerminalSdk.supportsReadersOfType(
-        params
-      );
+      const supportReaderResult =
+        await StripeTerminalSdk.supportsReadersOfType(params);
       return supportReaderResult;
     } catch (error) {
       return {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -44,4 +44,4 @@ export {
 export { requestNeededAndroidPermissions } from './utils/androidPermissionsUtils';
 
 //screens
-export { useTapToPayEducationView } from './functions';
+export { promptTapToPayEducationView } from './functions';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -42,3 +42,6 @@ export {
 
 // utils
 export { requestNeededAndroidPermissions } from './utils/androidPermissionsUtils';
+
+//screens
+export { useTapToPayEducationView } from './functions';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -578,6 +578,11 @@ export type TapToPayUxConfiguration = {
   colors?: Colors;
 };
 
+export type PromptTapToPayEducationResult = {
+  status: string;
+  message: string;
+}
+
 export type TapZone = {
   tapZoneIndicator?: TapZoneIndicator;
   tapZonePosition?: TapZonePosition;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -581,7 +581,7 @@ export type TapToPayUxConfiguration = {
 export type PromptTapToPayEducationResult = {
   status: string;
   message: string;
-}
+};
 
 export type TapZone = {
   tapZoneIndicator?: TapZoneIndicator;


### PR DESCRIPTION
## Summary

I added a function to trigger the popup to "educate merchants" as it is one of apple's requirements for the tap to pay entitlement
## Motivation

It fixes #885 and would like to use it in my own app

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.

**Need help on setting up documentation**

## Usage:

You can use this function by importing it like so:

`import { promptTapToPayEducationView } from '@stripe/stripe-terminal-react-native'`

then trigger the function for the popup. 


![Screenshot 2025-02-09 at 11 31 56 PM](https://github.com/user-attachments/assets/99337f2c-0d8d-40d8-a336-f0574d6c8e3f)
