### PR TITLE
[WIP] Change setupIntentScreen check condition

### DIFF
--- a/dev-app/src/App.tsx
+++ b/dev-app/src/App.tsx
@@ -64,6 +64,7 @@ export type RouteParamList = {
   };
   SetupIntentScreen: {
     discoveryMethod: Reader.DiscoveryMethod;
+    deviceType: Reader.DeviceType | undefined;
   };
   DiscoverReadersScreen: {
     simulated: boolean;

--- a/dev-app/src/screens/HomeScreen.tsx
+++ b/dev-app/src/screens/HomeScreen.tsx
@@ -223,7 +223,7 @@ export default function HomeScreen() {
         <ListItem
           title="Store card via Setup Intents"
           onPress={() => {
-            navigation.navigate('SetupIntentScreen', { discoveryMethod });
+            navigation.navigate('SetupIntentScreen', { discoveryMethod, deviceType: deviceType, });
           }}
         />
         <ListItem

--- a/dev-app/src/screens/SetupIntentScreen.tsx
+++ b/dev-app/src/screens/SetupIntentScreen.tsx
@@ -31,7 +31,7 @@ export default function SetupIntentScreen() {
   const { addLogs, clearLogs } = useContext(LogContext);
   const navigation = useNavigation<NavigationProp<RouteParamList>>();
   const { params } = useRoute<RouteProp<RouteParamList, 'SetupIntentScreen'>>();
-  const { discoveryMethod } = params;
+  const { deviceType, discoveryMethod } = params;
   const [enableCustomerCancellation, setEnableCustomerCancellation] =
     useState(false);
   const [moto, setMoto] = useState(false);
@@ -185,7 +185,7 @@ export default function SetupIntentScreen() {
     let setupIntent: SetupIntent.Type | undefined;
     let setupIntentError: StripeError<CommonError> | undefined;
 
-    if (discoveryMethod === 'internet') {
+    if (deviceType === 'verifoneP400') {
       const resp = await api.createSetupIntent({});
 
       if ('error' in resp) {


### PR DESCRIPTION
## Summary

Follow the flow in CollectCardPaymentScreen to change createSetupIntent check from checking `discoveryMethod == internet` to `deviceType == verifoneP400`. In order to make general internet connection can use the moto flow in dev-app.

## Motivation

https://jira.corp.stripe.com/browse/TERMINAL-44237 

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
