### PR TITLE
Make collectData callbacks uniform; bump gradle to 8.7.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.1'
+        classpath 'com.android.tools.build:gradle:8.7.2'
         // noinspection DifferentKotlinGradleVersion
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'org.codehaus.groovy:groovy-json:3.0.10'

--- a/ios/StripeTerminalReactNative.swift
+++ b/ios/StripeTerminalReactNative.swift
@@ -1038,7 +1038,7 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, MobileReade
                 if let error = error as NSError? {
                     resolve(Errors.createError(nsError: error))
                 } else if let collectedData {
-                    resolve(Mappers.mapFromCollectedData(collectedData))
+                    resolve(["collectedData": Mappers.mapFromCollectedData(collectedData)])
                 } else {
                     resolve([:])
                 }

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -841,9 +841,7 @@ export async function collectData(
   return Logger.traceSdkMethod(async () => {
     try {
       const response = await StripeTerminalSdk.collectData(params);
-      return {
-        collectedData: response,
-      };
+      return response;
     } catch (error) {
       return {
         error: error as any,


### PR DESCRIPTION
## Summary

Fix RN implementations of CollectedDataCallbacks. #849 unfortunately only fixed an issue on iOS, and it turns out the Android implementation was already correctly wrapping collectData in the proper `{ collectedData: <object> }`. This PR fixes the iOS implementation and undoes #849 

Also bumped gradle to 8.7.2 because I was running into cmake issues locally when building. I can revert if people have FUD

## Motivation

Jira ticket from QA: https://jira.corp.stripe.com/browse/TERMINAL-44410

## Testing
Tested manually on iOS + Android using `npx react-native run-ios` `npx react-native run-android` 
- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
