### PR TITLE
Add Client side create button to the dev app

### DIFF
--- a/dev-app/src/screens/CollectCardPaymentScreen.tsx
+++ b/dev-app/src/screens/CollectCardPaymentScreen.tsx
@@ -127,6 +127,7 @@ export default function CollectCardPaymentScreen() {
   const { params } =
     useRoute<RouteProp<RouteParamList, 'CollectCardPaymentScreen'>>();
   const { simulated, discoveryMethod, deviceType } = params;
+  const [enableClientSideCreate, setClientSideCreate] = useState(deviceType !== 'verifoneP400');
   const { addLogs, clearLogs, setCancel } = useContext(LogContext);
   const navigation = useNavigation<NavigationProp<RouteParamList>>();
 
@@ -205,7 +206,7 @@ export default function CollectCardPaymentScreen() {
     let paymentIntent: PaymentIntent.Type | undefined;
     let paymentIntentError: StripeError<CommonError> | undefined;
 
-    if (deviceType === 'verifoneP400') {
+    if (deviceType === 'verifoneP400' || !enableClientSideCreate) {
       const resp = await api.createPaymentIntent({
         amount: Number(inputValues.amount),
         currency: inputValues.currency,
@@ -686,6 +687,21 @@ export default function CollectCardPaymentScreen() {
                       )
                     );
                   }
+                }}
+              />
+            }
+          />
+        </List>
+        <List bolded={false} topSpacing={false} title="CLIENT SIDE">
+          <ListItem
+            title="Enable Client Side Create"
+            rightElement={
+              <Switch
+                testID="enable-client-side-create"
+                value={enableClientSideCreate}
+                disabled={deviceType === 'verifoneP400'}
+                onValueChange={(value) => {
+                  setClientSideCreate(value);
                 }}
               />
             }


### PR DESCRIPTION

## Summary
Add `Create Client Side` switch to the dev test application, when enabled it’ll create payment intents using the terminal sdk, and when disabled it’ll create  payment intents via the stripe api. Client side create is always disabled for p400 readers as it doesn’t support that functionality.

## Motivation
So testing create PI -> retrievePI -> collect path does not require code changes.

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
![Screenshot 2025-03-21 at 7 39 24 PM](https://github.com/user-attachments/assets/f3a65ae8-cabc-4ada-9b5e-abcd67c2f552)

