### PR TITLE
Interface refine for connectReader

### DIFF
--- a/src/hooks/useStripeTerminal.tsx
+++ b/src/hooks/useStripeTerminal.tsx
@@ -23,6 +23,11 @@ import type {
   CancelPaymentMethodParams,
   CollectDataParams,
   TapToPayUxConfiguration,
+  ConnectBluetoothReaderParams,
+  ConnectUsbReaderParams,
+  ConnectTapToPayParams,
+  ConnectHandoffParams,
+  ConnectInternetReaderParams,
   ConnectReaderParams,
 } from '../types';
 import {
@@ -406,7 +411,7 @@ export function useStripeTerminal(props?: Props) {
 
   const _connectReader = useCallback(
     async (
-      params: ConnectReaderParams,
+      params: ConnectReaderParams | ConnectBluetoothReaderParams | ConnectUsbReaderParams | ConnectTapToPayParams | ConnectHandoffParams | ConnectInternetReaderParams,
       discoveryMethod: Reader.DiscoveryMethod
     ) => {
       if (!_isInitialized()) {

--- a/src/hooks/useStripeTerminal.tsx
+++ b/src/hooks/useStripeTerminal.tsx
@@ -28,7 +28,6 @@ import type {
   ConnectTapToPayParams,
   ConnectHandoffParams,
   ConnectInternetReaderParams,
-  ConnectReaderParams,
 } from '../types';
 import {
   discoverReaders,
@@ -411,7 +410,7 @@ export function useStripeTerminal(props?: Props) {
 
   const _connectReader = useCallback(
     async (
-      params: ConnectReaderParams | ConnectBluetoothReaderParams | ConnectUsbReaderParams | ConnectTapToPayParams | ConnectHandoffParams | ConnectInternetReaderParams,
+      params: ConnectBluetoothReaderParams | ConnectUsbReaderParams | ConnectTapToPayParams | ConnectHandoffParams | ConnectInternetReaderParams,
       discoveryMethod: Reader.DiscoveryMethod
     ) => {
       if (!_isInitialized()) {


### PR DESCRIPTION
## Summary

Interface refine for connectReader

## Motivation
https://jira.corp.stripe.com/browse/TERMINAL-44261

We'd like to clear communicate with user that `connectReader` can accept parameter like: `ConnectBluetoothReaderParams | ConnectUsbReaderParams | ConnectTapToPayParams | ConnectHandoffParams | ConnectInternetReaderParams`

Screenshot in VSCode:
<img width="740" alt="image" src="https://github.com/user-attachments/assets/6fb4dd96-9710-447b-b6b7-ba1b05620388" />


## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
