### PR TITLE
Update maestro on ios

### DIFF
--- a/dev-app/src/screens/LogListScreen.tsx
+++ b/dev-app/src/screens/LogListScreen.tsx
@@ -51,6 +51,7 @@ const LogListScreen = () => {
         <List key={`${log.name}-${lidx}`} title={log.name}>
           {log.events.map((event, idx) => (
             <ListItem
+              testID={`${event.name}`}
               key={`${event.name}-${idx}`}
               title={event.name}
               description={event.description}

--- a/maestro/e2e/collectPayment.yaml
+++ b/maestro/e2e/collectPayment.yaml
@@ -5,31 +5,31 @@ appId: com.dev.app.stripeterminalreactnative
 
 - scrollUntilVisible:
     element:
-      text: "Create"
+      id: "Create"
 - scrollUntilVisible:
     element:
-      text: "Created"
+      id: "Created"
 - scrollUntilVisible:
     element:
-      text: "Collect"
+      id: "Collect"
 - scrollUntilVisible:
     element:
-      text: "insertCard / swipeCard / tapCard"
+      id: "insertCard / swipeCard / tapCard"
 - scrollUntilVisible:
     element:
-      text: "removeCard"
+      id: "removeCard"
 - scrollUntilVisible:
     element:
-      text: "Collected"
+      id: "Collected"
 - scrollUntilVisible:
     element:
-      text: "Process"
+      id: "Process"
 - scrollUntilVisible:
     element:
-      text: "Confirmed"
+      id: "Confirmed"
 - scrollUntilVisible:
     element:
-      text: "Capture"
+      id: "Capture"
 - scrollUntilVisible:
     element:
-      text: "Captured"
+      id: "Captured"

--- a/maestro/e2e/connectReader.yaml
+++ b/maestro/e2e/connectReader.yaml
@@ -14,7 +14,7 @@ appId: com.dev.app.stripeterminalreactnative
         - tapOn: "Update required"
 
 - tapOn:
-    id: "reader-1"
+    id: "reader-0"
 - runFlow:
     when:
         true: ${updateRequired == true}

--- a/maestro/e2e/inpersonRefund.yaml
+++ b/maestro/e2e/inpersonRefund.yaml
@@ -21,7 +21,7 @@ appId: com.dev.app.stripeterminalreactnative
 
 - scrollUntilVisible:
     element:
-      text: "Collect"
+      id: "Collect"
 - scrollUntilVisible:
     element:
-      text: "Failed"
+      id: "Failed"

--- a/maestro/e2e/setupIntent.yaml
+++ b/maestro/e2e/setupIntent.yaml
@@ -10,22 +10,22 @@ appId: com.dev.app.stripeterminalreactnative
 
 - scrollUntilVisible:
     element:
-      text: "Create"
+      id: "Create"
 - scrollUntilVisible:
     element:
-      text: "Collect"
+      id: "Collect"
 - scrollUntilVisible:
     element:
-      text: "insertCard / swipeCard / tapCard"
+      id: "insertCard / swipeCard / tapCard"
 - scrollUntilVisible:
     element:
-      text: "removeCard"
+      id: "removeCard"
 - scrollUntilVisible:
     element:
-      text: "Created"
+      id: "Created"
 - scrollUntilVisible:
     element:
-      text: "Process"
+      id: "Process"
 - scrollUntilVisible:
     element:
-      text: "Finished"
+      id: "Finished"


### PR DESCRIPTION
## Summary

Update maestro on ios

## Motivation

Fetch text in LogListScreen is not working from maestro so we'd change to id comparison.
And also change the device index as in ios case only has 1 device.

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [ ] I tested this manually
- [x] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
