### PR TITLE
Adding two scripts for speed-up clean & rebuild monoproject

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "pods": "cd dev-app && pod-install --quiet",
     "clean": "rm -rf node_modules && rm -rf dev-app/node_modules && rm -rf dev-app/ios/Pods",
     "bootstrap": "yarn dev-app && yarn && yarn pods",
+    "deep-clean": "rm -rf node_modules dev-app/node_modules dev-app/ios/Pods dev-app/android/.gradle dev-app/android/.cxx dev-app/android/app/build dev-app/ios/build ~/Library/Developer/Xcode/DerivedData",
+    "reset": "yarn deep-clean && yarn bootstrap",
     "dev-app:build:android:release": "cd dev-app/android && ./gradlew assembleRelease ; cd -",
     "e2e:build:example:ios": "detox build --configuration ios.example",
     "e2e:build:example:android": "detox build --configuration android.example",


### PR DESCRIPTION
## Summary

The two scripts are:
`deep-clean`: compared to the existing clean script, this clean data in the dev-app android/ios folders
`reset`: combine the deep-clean & bootstrap, if we want to clean the cache and rebuild the whole monorepo, this is the only command we need.

## Motivation

When setting up my environment and struggling with the frameworks and dependencies version, these commands can help me verify my changes quickly.

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
