### PR TITLE
Extract maestro config APP_ID and use Id for matching

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -85,7 +85,7 @@ workflows:
           inputs:
             - content: |-
                 curl -fsSL "https://get.maestro.mobile.dev" | bash
-                ~/.maestro/bin/maestro test maestro/app.yml
+                ~/.maestro/bin/maestro test -e APP_ID=com.dev.app.stripeterminalreactnative maestro/app.yml
           title: install maestro & run tests
     before_run:
       - prep_all

--- a/dev-app/src/screens/CollectCardPaymentScreen.tsx
+++ b/dev-app/src/screens/CollectCardPaymentScreen.tsx
@@ -1148,6 +1148,7 @@ export default function CollectCardPaymentScreen() {
           }`}
         >
           <ListItem
+            testID='collect-payment-button'
             color={colors.blue}
             title="Collect payment"
             onPress={_createPaymentIntent}

--- a/dev-app/src/screens/HomeScreen.tsx
+++ b/dev-app/src/screens/HomeScreen.tsx
@@ -187,6 +187,7 @@ export default function HomeScreen() {
 
       <List title="COMMON WORKFLOWS">
         <ListItem
+          testID='collect-payment-method-button'
           title="Collect card payment"
           onPress={() => {
             navigation.navigate('CollectCardPaymentScreen', {
@@ -223,12 +224,14 @@ export default function HomeScreen() {
           }}
         />
         <ListItem
+          testID='setup-intent-button'
           title="Store card via Setup Intents"
           onPress={() => {
             navigation.navigate('SetupIntentScreen', { discoveryMethod, deviceType: deviceType, });
           }}
         />
         <ListItem
+          testID='in-person-refund-button'
           title="In-Person Refund"
           onPress={() => {
             navigation.navigate('RefundPaymentScreen', {
@@ -345,6 +348,7 @@ export default function HomeScreen() {
               }}
             />
             <ListItem
+              testID='discover-readers-button'
               title="Discover Readers"
               color={colors.blue}
               disabled={!account}

--- a/dev-app/src/screens/UpdateReaderScreen.tsx
+++ b/dev-app/src/screens/UpdateReaderScreen.tsx
@@ -70,7 +70,11 @@ export default function UpdateReaderScreen() {
       </List>
 
       <List>
-        <ListItem visible={startToUpdate} title="Required update in progress" />
+        <ListItem
+          testID='required-update-in-progress'
+          visible={startToUpdate}
+          title="Required update in progress"
+        />
         <ListItem
           visible={!startToUpdate}
           title="Install update"

--- a/maestro/app.yml
+++ b/maestro/app.yml
@@ -1,4 +1,4 @@
-appId: com.dev.app.stripeterminalreactnative
+appId: ${APP_ID}
 tags:
   - passing
 ---
@@ -10,7 +10,7 @@ tags:
 - runFlow: 
     file: e2e/connectReader.yaml
     env:
-      discoveryMethod: "Bluetooth Scan"
+      discoveryMethod: "bt-scn-btn"
 - runFlow: e2e/checkIfConnected.yaml
 
 
@@ -22,7 +22,7 @@ tags:
 - runFlow: 
     file: e2e/connectReader.yaml
     env:
-      discoveryMethod: "Bluetooth Scan"
+      discoveryMethod: "bt-scn-btn"
       updateRequired: true
 - runFlow: e2e/checkIfConnected.yaml
 
@@ -34,7 +34,7 @@ tags:
 - runFlow:
     file: e2e/connectReader.yaml
     env:
-      discoveryMethod: "Bluetooth Proximity"
+      discoveryMethod: "bt-prox-btn"
     when:
         platform: ios
 
@@ -46,7 +46,7 @@ tags:
 - runFlow:
     file: e2e/connectReader.yaml
     env:
-      discoveryMethod: "Internet"
+      discoveryMethod: "internet-btn"
 
 # TODO ios only
 # Required update impossible due to low battery
@@ -59,7 +59,7 @@ tags:
 - runFlow:
     file: e2e/connectReader.yaml
     env:
-      discoveryMethod: "Bluetooth Scan"
+      discoveryMethod: "bt-scn-btn"
 - runFlow:
     file: e2e/collectPayment.yaml
 
@@ -71,7 +71,7 @@ tags:
 - runFlow:
     file: e2e/connectReader.yaml
     env:
-      discoveryMethod: "Bluetooth Scan"
+      discoveryMethod: "bt-scn-btn"
 - runFlow:
     file: e2e/setupIntent.yaml
 
@@ -83,6 +83,6 @@ tags:
 - runFlow:
     file: e2e/connectReader.yaml
     env:
-      discoveryMethod: "Bluetooth Scan"
+      discoveryMethod: "bt-scn-btn"
 - runFlow:
     file: e2e/inpersonRefund.yaml

--- a/maestro/e2e/checkIfConnected.yaml
+++ b/maestro/e2e/checkIfConnected.yaml
@@ -1,8 +1,8 @@
-appId: com.dev.app.stripeterminalreactnative
+appId: ${APP_ID}
 ---
 - extendedWaitUntil:
     visible:
         id: "home-screen"
     timeout: 60000
 - assertVisible:
-    text: "Disconnect"
+    id: "disconnect-button"

--- a/maestro/e2e/collectPayment.yaml
+++ b/maestro/e2e/collectPayment.yaml
@@ -1,7 +1,9 @@
-appId: com.dev.app.stripeterminalreactnative
+appId: ${APP_ID}
 ---
-- tapOn: "Collect card payment"
-- tapOn: "Collect payment"
+- tapOn:
+    id: "collect-payment-method-button"
+- tapOn:
+    id: "collect-payment-button"
 
 - scrollUntilVisible:
     element:

--- a/maestro/e2e/connectReader.yaml
+++ b/maestro/e2e/connectReader.yaml
@@ -1,9 +1,11 @@
-appId: com.dev.app.stripeterminalreactnative
+appId: ${APP_ID}
 ---
 - tapOn:
     id: "discovery-method-button"
-- tapOn: ${discoveryMethod}
-- tapOn: "Discover Readers"
+- tapOn:
+    id: ${discoveryMethod}
+- tapOn:
+    id: "discover-readers-button"
 
 - runFlow:
     when:
@@ -11,7 +13,6 @@ appId: com.dev.app.stripeterminalreactnative
     commands:
         - tapOn:
             id: "update-plan-picker"
-        - tapOn: "Update required"
 
 - tapOn:
     id: "reader-0"
@@ -20,5 +21,6 @@ appId: com.dev.app.stripeterminalreactnative
         true: ${updateRequired == true}
     commands:
         - extendedWaitUntil:
-            visible: "Required update in progress"
+            visible:
+                id: "required-update-in-progress"
             timeout: 16000

--- a/maestro/e2e/inpersonRefund.yaml
+++ b/maestro/e2e/inpersonRefund.yaml
@@ -1,9 +1,10 @@
-appId: com.dev.app.stripeterminalreactnative
+appId: ${APP_ID}
 ---
 - scrollUntilVisible:
     element:
-      text: "In-Person Refund"
-- tapOn: "In-Person Refund"
+      id: "in-person-refund-button"
+- tapOn:
+    id: "in-person-refund-button"
 
 - tapOn:
     id: "charge-id-text-field"

--- a/maestro/e2e/setupIntent.yaml
+++ b/maestro/e2e/setupIntent.yaml
@@ -1,9 +1,10 @@
-appId: com.dev.app.stripeterminalreactnative
+appId: ${APP_ID}
 ---
 - scrollUntilVisible:
     element:
-      text: "Store card via Setup Intents"
-- tapOn: "Store card via Setup Intents"
+      id: "setup-intent-button"
+- tapOn:
+    id: "setup-intent-button"
 
 - tapOn:
     id: "collect-setup-intent-button"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "e2e:test:ios": "detox test --configuration ios --take-screenshots failing --loglevel verbose",
     "e2e:build:android:release": "detox build --configuration android.emu.release",
     "e2e:build:ios:release": "detox build --configuration ios.sim.release",
-    "e2e:test:android:release": "maestro test maestro/app.yml",
+    "e2e:test:android:release": "maestro test -e APP_ID=com.dev.app.stripeterminalreactnative maestro/app.yml",
     "e2e:test:ios:release": " detox test --configuration ios.sim.release --take-screenshots failing --loglevel verbose",
     "get:testbutler": "curl -f -o ./test-butler-app.apk https://repo1.maven.org/maven2/com/linkedin/testbutler/test-butler-app/2.2.1/test-butler-app-2.2.1.apk",
     "docs": "npx typedoc ./src/index.tsx --out ./docs/api-reference --tsconfig ./tsconfig.json --readme none",


### PR DESCRIPTION
## Summary

Extract maestro config APP_ID and use Id for matching

## Motivation

- Extract APP_ID for future iOS support
- Use Id for matching

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
