### PR TITLE
Update ios e2e test using maestro

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -102,12 +102,18 @@ workflows:
             - command: e2e:build:ios:release
             - cache_local_deps: 'yes'
           title: build for detox
-      - yarn@0:
+      - xcode-start-simulator:
+          inputs:
+            - destination: platform=iOS Simulator,name=iPhone 16,OS=latest
+            - wait_for_boot_timeout: 90
+      - script@1:
           is_skippable: true
           inputs:
-            - command: e2e:test:ios:release
-            - cache_local_deps: 'yes'
-          title: test detox
+            - content: |-
+                xcrun simctl install Booted dev-app/ios/build/Build/Products/Release-iphonesimulator/StripeTerminalReactNativeDevApp.app
+                curl -fsSL "https://get.maestro.mobile.dev" | bash
+                ~/.maestro/bin/maestro test -e APP_ID=com.stripe.terminal.reactnative.dev.app maestro/app.yml
+          title: install maestro & run tests
     before_run:
       - prep_all
       - setup_cocoapods

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "e2e:build:android:release": "detox build --configuration android.emu.release",
     "e2e:build:ios:release": "detox build --configuration ios.sim.release",
     "e2e:test:android:release": "maestro test -e APP_ID=com.dev.app.stripeterminalreactnative maestro/app.yml",
-    "e2e:test:ios:release": " detox test --configuration ios.sim.release --take-screenshots failing --loglevel verbose",
+    "e2e:test:ios:release": "maestro test -e APP_ID=com.stripe.terminal.reactnative.dev.app maestro/app.yml",
     "get:testbutler": "curl -f -o ./test-butler-app.apk https://repo1.maven.org/maven2/com/linkedin/testbutler/test-butler-app/2.2.1/test-butler-app-2.2.1.apk",
     "docs": "npx typedoc ./src/index.tsx --out ./docs/api-reference --tsconfig ./tsconfig.json --readme none",
     "unit-test:android": "cd android && ./gradlew testDebugUnitTest",


### PR DESCRIPTION
## Summary

Update ios e2e test using maestro

## Motivation

Since detox is not working in ci env for iOS and we've migrate Android side, we'd like to move to maestro step by step on iOS as well.

Currently it support local test on simulator iPhone16 with simulate config is on and pre-set the merchant info.

Can trigger using `yarn e2e:test:ios:release` at root folder to verify/test.

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
