### PR TITLE
Add simulated Internet reader support for collecting inputs on iOS side

### DIFF
--- a/android/src/main/java/com/stripeterminalreactnative/Errors.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/Errors.kt
@@ -7,17 +7,6 @@ import com.stripe.stripeterminal.external.models.TerminalErrorCode
 import com.stripe.stripeterminal.external.models.TerminalException
 import kotlinx.coroutines.CancellationException
 
-enum class CommonError(val code: String) {
-    Failed("Failed"),
-    Canceled("Canceled"),
-    Unknown("Unknown")
-}
-
-data class StripeError(
-    val code: CommonError,
-    val message: String,
-)
-
 internal fun createError(throwable: Throwable): ReadableMap = nativeMapOf { putError(throwable) }
 
 internal fun WritableMap.putError(throwable: Throwable): ReadableMap = apply {

--- a/android/src/main/java/com/stripeterminalreactnative/Errors.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/Errors.kt
@@ -7,6 +7,17 @@ import com.stripe.stripeterminal.external.models.TerminalErrorCode
 import com.stripe.stripeterminal.external.models.TerminalException
 import kotlinx.coroutines.CancellationException
 
+enum class CommonError(val code: String) {
+    Failed("Failed"),
+    Canceled("Canceled"),
+    Unknown("Unknown")
+}
+
+data class StripeError(
+    val code: CommonError,
+    val message: String,
+)
+
 internal fun createError(throwable: Throwable): ReadableMap = nativeMapOf { putError(throwable) }
 
 internal fun WritableMap.putError(throwable: Throwable): ReadableMap = apply {

--- a/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
@@ -63,6 +63,9 @@ import com.stripe.stripeterminal.external.models.SetupIntentStatus
 import com.stripe.stripeterminal.external.models.SetupIntentUsage
 import com.stripe.stripeterminal.external.models.SignatureResult
 import com.stripe.stripeterminal.external.models.SimulateReaderUpdate
+import com.stripe.stripeterminal.external.models.SimulatedCollectInputsResult
+import com.stripe.stripeterminal.external.models.SimulatedCollectInputsResult.SimulatedCollectInputsResultSucceeded
+import com.stripe.stripeterminal.external.models.SimulatedCollectInputsResult.SimulatedCollectInputsResultTimeout
 import com.stripe.stripeterminal.external.models.SimulatedCollectInputsSkipBehavior
 import com.stripe.stripeterminal.external.models.TapToPayUxConfiguration
 import com.stripe.stripeterminal.external.models.TextResult
@@ -517,12 +520,17 @@ internal fun mapFromSimulateReaderUpdate(update: String): SimulateReaderUpdate {
     }
 }
 
-internal fun mapFromSimulatedCollectInputsSkipBehavior(behavior: String?): SimulatedCollectInputsSkipBehavior {
-    return when (behavior) {
+internal fun mapFromSimulatedCollectInputsBehavior(behavior: String?): SimulatedCollectInputsResult {
+    val skipBehavior = when (behavior) {
         "all" -> SimulatedCollectInputsSkipBehavior.ALL
         "none" -> SimulatedCollectInputsSkipBehavior.NONE
+        "timeout" -> null
         else -> SimulatedCollectInputsSkipBehavior.NONE
     }
+
+    return skipBehavior?.let {
+        SimulatedCollectInputsResultSucceeded(it)
+    } ?: SimulatedCollectInputsResultTimeout()
 }
 
 private fun convertToUnixTimestamp(timestamp: Long): String = (timestamp * 1000).toString()

--- a/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
@@ -521,16 +521,20 @@ internal fun mapFromSimulateReaderUpdate(update: String): SimulateReaderUpdate {
 }
 
 internal fun mapFromSimulatedCollectInputsBehavior(behavior: String?): SimulatedCollectInputsResult {
-    val skipBehavior = when (behavior) {
-        "all" -> SimulatedCollectInputsSkipBehavior.ALL
-        "none" -> SimulatedCollectInputsSkipBehavior.NONE
-        "timeout" -> null
-        else -> SimulatedCollectInputsSkipBehavior.NONE
+    return when (behavior) {
+        "all" -> {
+            SimulatedCollectInputsResultSucceeded(SimulatedCollectInputsSkipBehavior.ALL)
+        }
+        "none" -> {
+            SimulatedCollectInputsResultSucceeded(SimulatedCollectInputsSkipBehavior.NONE)
+        }
+        "timeout" -> {
+            SimulatedCollectInputsResultTimeout()
+        }
+        else -> {
+            SimulatedCollectInputsResultSucceeded(SimulatedCollectInputsSkipBehavior.NONE)
+        }
     }
-
-    return skipBehavior?.let {
-        SimulatedCollectInputsResultSucceeded(it)
-    } ?: SimulatedCollectInputsResultTimeout()
 }
 
 private fun convertToUnixTimestamp(timestamp: Long): String = (timestamp * 1000).toString()

--- a/android/src/main/java/com/stripeterminalreactnative/NativeTypeFactory.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/NativeTypeFactory.kt
@@ -12,7 +12,16 @@ import com.facebook.react.bridge.WritableNativeMap
  * [android.os.SystemClock.uptimeMillis] which can be challenging to mock.
  */
 object NativeTypeFactory {
+
+    /**
+     * Returns an empty WritableMap, which will be sent to JS as an empty object `{}`.
+     * This is the standard way to return an empty object from native to JavaScript.
+     */
     fun writableNativeMap(): WritableMap = WritableNativeMap()
 
+    /**
+     * Returns an empty WritableArray, which will be sent to JS as an empty array `[]`.
+     * This is the standard way to return an empty array from native to JavaScript.
+     */
     fun writableNativeArray(): WritableArray = WritableNativeArray()
 }

--- a/android/src/main/java/com/stripeterminalreactnative/ReactExtensions.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/ReactExtensions.kt
@@ -1,5 +1,6 @@
 package com.stripeterminalreactnative
 
+import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.modules.core.DeviceEventManagerModule
@@ -19,5 +20,9 @@ internal object ReactExtensions {
                     }
                 }
             )
+    }
+
+    fun Promise.reject(stripeError: StripeError) {
+        this.reject(stripeError.code.code, stripeError.message)
     }
 }

--- a/android/src/main/java/com/stripeterminalreactnative/ReactExtensions.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/ReactExtensions.kt
@@ -21,8 +21,4 @@ internal object ReactExtensions {
                 }
             )
     }
-
-    fun Promise.reject(stripeError: StripeError) {
-        this.reject(stripeError.code.code, stripeError.message)
-    }
 }

--- a/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
@@ -55,8 +55,6 @@ import com.stripe.stripeterminal.external.models.SetupIntentCancellationParamete
 import com.stripe.stripeterminal.external.models.SetupIntentConfiguration
 import com.stripe.stripeterminal.external.models.SignatureInput
 import com.stripe.stripeterminal.external.models.SimulatedCard
-import com.stripe.stripeterminal.external.models.SimulatedCollectInputsResult
-import com.stripe.stripeterminal.external.models.SimulatedCollectInputsSkipBehavior
 import com.stripe.stripeterminal.external.models.SimulatorConfiguration
 import com.stripe.stripeterminal.external.models.TapToPayUxConfiguration
 import com.stripe.stripeterminal.external.models.TerminalErrorCode
@@ -65,6 +63,7 @@ import com.stripe.stripeterminal.external.models.TextInput
 import com.stripe.stripeterminal.external.models.TippingConfiguration
 import com.stripe.stripeterminal.external.models.Toggle
 import com.stripe.stripeterminal.external.models.ToggleValue
+import com.stripeterminalreactnative.ReactExtensions.reject
 import com.stripeterminalreactnative.callback.NoOpCallback
 import com.stripeterminalreactnative.callback.RNCollectInputResultCallback
 import com.stripeterminalreactnative.callback.RNCollectedDataCallback
@@ -236,12 +235,20 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
 
     @ReactMethod
     @Suppress("unused")
-    fun setSimulatedCollectInputsResult(simulatedCollectInputsSkipBehavior: String, promise: Promise) {
+    fun setSimulatedCollectInputsResult(simulatedCollectInputsBehavior: String, promise: Promise) {
+        val validBehavior = setOf("all", "none", "timeout")
+        if (simulatedCollectInputsBehavior !in validBehavior) {
+            promise.reject(
+                StripeError(
+                    code = CommonError.Failed,
+                    message = "The simulatedCollectInputsBehavior must be \"all\", \"none\", or \"timeout\"."
+                )
+            )
+        }
+
         terminal.simulatorConfiguration = SimulatorConfiguration(
-            simulatedCollectInputsResult = SimulatedCollectInputsResult.SimulatedCollectInputsResultSucceeded(
-                simulatedCollectInputsSkipBehavior = mapFromSimulatedCollectInputsSkipBehavior(
-                    simulatedCollectInputsSkipBehavior
-                ),
+            simulatedCollectInputsResult = mapFromSimulatedCollectInputsBehavior(
+                simulatedCollectInputsBehavior
             )
         )
         promise.resolve(NativeTypeFactory.writableNativeMap())

--- a/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
@@ -63,7 +63,6 @@ import com.stripe.stripeterminal.external.models.TextInput
 import com.stripe.stripeterminal.external.models.TippingConfiguration
 import com.stripe.stripeterminal.external.models.Toggle
 import com.stripe.stripeterminal.external.models.ToggleValue
-import com.stripeterminalreactnative.ReactExtensions.reject
 import com.stripeterminalreactnative.callback.NoOpCallback
 import com.stripeterminalreactnative.callback.RNCollectInputResultCallback
 import com.stripeterminalreactnative.callback.RNCollectedDataCallback
@@ -239,10 +238,8 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
         val validBehavior = setOf("all", "none", "timeout")
         if (simulatedCollectInputsBehavior !in validBehavior) {
             promise.reject(
-                StripeError(
-                    code = CommonError.Failed,
-                    message = "The simulatedCollectInputsBehavior must be \"all\", \"none\", or \"timeout\"."
-                )
+                code = "Failed",
+                message = "The simulatedCollectInputsBehavior must be \"all\", \"none\", or \"timeout\"."
             )
         }
 

--- a/android/src/test/java/com/stripeterminalreactnative/MapperTest.kt
+++ b/android/src/test/java/com/stripeterminalreactnative/MapperTest.kt
@@ -4,6 +4,7 @@ import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.stripe.stripeterminal.external.models.CardPresentRequestPartialAuthorization
 import com.stripe.stripeterminal.external.models.PaymentMethodType
+import com.stripe.stripeterminal.external.models.SimulatedCollectInputsResult
 import com.stripe.stripeterminal.external.models.SimulatedCollectInputsSkipBehavior
 import io.mockk.every
 import io.mockk.mockk
@@ -79,10 +80,29 @@ class MapperTest {
     }
 
     @Test
-    fun `test mapFromSimulatedCollectInputsSkipBehavior transform`() {
-        assertEquals(mapFromSimulatedCollectInputsSkipBehavior("none"), SimulatedCollectInputsSkipBehavior.NONE)
-        assertEquals(mapFromSimulatedCollectInputsSkipBehavior("all"), SimulatedCollectInputsSkipBehavior.ALL)
-        assertEquals(mapFromSimulatedCollectInputsSkipBehavior(""), SimulatedCollectInputsSkipBehavior.NONE)
+    fun `test mapFromSimulatedCollectInputsBehavior transform`() {
+        val notSkipInputBehavior = mapFromSimulatedCollectInputsBehavior("none")
+        assertTrue {
+            notSkipInputBehavior is SimulatedCollectInputsResult.SimulatedCollectInputsResultSucceeded &&
+                notSkipInputBehavior.simulatedCollectInputsSkipBehavior == SimulatedCollectInputsSkipBehavior.NONE
+        }
+
+        val skipAllInputBehavior = mapFromSimulatedCollectInputsBehavior("all")
+        assertTrue {
+            skipAllInputBehavior is SimulatedCollectInputsResult.SimulatedCollectInputsResultSucceeded &&
+                skipAllInputBehavior.simulatedCollectInputsSkipBehavior == SimulatedCollectInputsSkipBehavior.ALL
+        }
+
+        val timeoutBehavior = mapFromSimulatedCollectInputsBehavior("timeout")
+        assertTrue {
+            timeoutBehavior is SimulatedCollectInputsResult.SimulatedCollectInputsResultTimeout
+        }
+
+        val unexpectedBehavior = mapFromSimulatedCollectInputsBehavior("unexpected")
+        assertTrue {
+            unexpectedBehavior is SimulatedCollectInputsResult.SimulatedCollectInputsResultSucceeded &&
+                unexpectedBehavior.simulatedCollectInputsSkipBehavior == SimulatedCollectInputsSkipBehavior.NONE
+        }
     }
 }
 

--- a/dev-app/ios/Podfile.lock
+++ b/dev-app/ios/Podfile.lock
@@ -1676,11 +1676,11 @@ PODS:
   - SocketRocket (0.7.1)
   - stripe-terminal-react-native (0.0.1-beta.25):
     - React-Core
-    - StripeTerminal (~> 4.3.0)
+    - StripeTerminal (~> 4.4.0)
   - stripe-terminal-react-native/Tests (0.0.1-beta.25):
     - React-Core
-    - StripeTerminal (~> 4.3.0)
-  - StripeTerminal (4.3.0)
+    - StripeTerminal (~> 4.4.0)
+  - StripeTerminal (4.4.0)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -1984,8 +1984,8 @@ SPEC CHECKSUMS:
   RNGestureHandler: 66e593addd8952725107cfaa4f5e3378e946b541
   RNScreens: 0f01bbed9bd8045a8d58e4b46993c28c7f498f3c
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  stripe-terminal-react-native: 8918892108749dde11af463da26ac314caebd0a3
-  StripeTerminal: 056d0d3b5e2f2edbc5f8b6314ec5f2b037898c72
+  stripe-terminal-react-native: 5c01b832aaf1ec402ba9d69a97897b622da6ce69
+  StripeTerminal: 7bcb4ed7561f862b8005256be18d2b5198a7f75e
   Yoga: 31a098f74c16780569aebd614a0f37a907de0189
 
 PODFILE CHECKSUM: 7bb7fbbd263bda35e47b3f64ad5fbd6c589aa428

--- a/dev-app/src/screens/CollectInputsScreen.tsx
+++ b/dev-app/src/screens/CollectInputsScreen.tsx
@@ -15,9 +15,10 @@ import { useNavigation, useRoute, type NavigationProp, type RouteProp } from '@r
 import type { RouteParamList } from '../App';
 import { Picker } from '@react-native-picker/picker';
 
-const SKIP_BEHAVIOR = [
+const COLLECT_PAYMENT_INPUT_BEHAVIOR = [
   { value: 'all', label: 'all' },
   { value: 'none', label: 'none' },
+  { value: 'timeout', label: 'timeout' },
 ];
 
 export default function CollectInputsScreen() {
@@ -27,7 +28,7 @@ export default function CollectInputsScreen() {
   const { collectInputs, cancelCollectInputs, setSimulatedCollectInputsResult } = useStripeTerminal();
   const { addLogs, clearLogs, setCancel } = useContext(LogContext);
   const navigation = useNavigation<NavigationProp<RouteParamList>>();
-  const [simulatedCollectInputsSkipBehavior, setSimulatedCollectInputsSkipBehavior] = useState<string>("none");
+  const [simulatedCollectInputsBehavior, setSimulatedCollectInputsBehavior] = useState<string>(COLLECT_PAYMENT_INPUT_BEHAVIOR[0].value);
 
   const _collectInputs = async (params: ICollectInputsParameters) => {
     clearLogs();
@@ -48,8 +49,8 @@ export default function CollectInputsScreen() {
       ],
     });
 
-    if (simulated && Platform.OS === 'android') { // only android support it now
-      const simulateResultResponse = await setSimulatedCollectInputsResult(simulatedCollectInputsSkipBehavior);
+    if (simulated) {
+      const simulateResultResponse = await setSimulatedCollectInputsResult(simulatedCollectInputsBehavior);
       if (simulateResultResponse.error) {
         addLogs({
           name: 'Simulate Collect Inputs Result',
@@ -200,19 +201,19 @@ export default function CollectInputsScreen() {
           }}
         />
       </List>
-      {/* only android support it now */}
-      {(simulated && Platform.OS === 'android') ? 
-        <List bolded={false} topSpacing={false} title="SIMULATED COLLECT INPUTS SKIP BEHAVIOR">
+
+      {simulated ?
+        <List bolded={false} topSpacing={false} title="SIMULATED COLLECT INPUTS BEHAVIOR">
           <Picker
-            selectedValue={simulatedCollectInputsSkipBehavior}
+            selectedValue={simulatedCollectInputsBehavior}
             style={styles.picker}
             itemStyle={styles.pickerItem}
-            testID="select-skip-behavior"
+            testID="select-behavior"
             onValueChange={(value) =>
-              setSimulatedCollectInputsSkipBehavior(value)
+              setSimulatedCollectInputsBehavior(value)
             }
           >
-            {SKIP_BEHAVIOR.map((a) => (
+            {COLLECT_PAYMENT_INPUT_BEHAVIOR.map((a) => (
               <Picker.Item
                 key={a.value}
                 label={a.label}

--- a/dev-app/src/screens/CollectInputsScreen.tsx
+++ b/dev-app/src/screens/CollectInputsScreen.tsx
@@ -16,9 +16,9 @@ import type { RouteParamList } from '../App';
 import { Picker } from '@react-native-picker/picker';
 
 const COLLECT_PAYMENT_INPUT_BEHAVIOR = [
-  { value: 'all', label: 'all' },
-  { value: 'none', label: 'none' },
-  { value: 'timeout', label: 'timeout' },
+  { value: 'all', label: 'Success with skipping' },
+  { value: 'none', label: 'Success without skipping' },
+  { value: 'timeout', label: 'Timeout' },
 ];
 
 export default function CollectInputsScreen() {

--- a/ios/Errors.swift
+++ b/ios/Errors.swift
@@ -5,6 +5,17 @@ enum CommonErrorType: String {
     case AlreadyDiscovering
 }
 
+enum BridgeCommonError: String {
+  case failed = "Failed"
+  case canceled = "Canceled"
+  case unknown = "Unknown"
+}
+
+struct StripeError {
+    let code: BridgeCommonError
+    let message: String
+}
+
 class Errors {
     class func validateRequiredParameters(params: NSDictionary, requiredParams: [String]) -> String? {
         var invalid: [String] = []
@@ -29,6 +40,12 @@ class Errors {
     class func createError(nsError: NSError) -> [String: Any] {
         return createError(code: ErrorCode.Code.init(rawValue: nsError.code) ?? ErrorCode.unexpectedSdkError, message: nsError.localizedDescription)
     }
+  
+    class func reject(_ reject: RCTPromiseRejectBlock, code: CommonErrorType, message: String) {
+        let errorDict = createError(errorCode: code.rawValue, message: message)
+        let error = errorDict["error"] as? [String: String]
+        reject(error?["code"] ?? "Unknown", error?["message"], nil)
+    }
 
     private class func createError(errorCode: String, message: String) -> [String: Any] {
         let error = [
@@ -47,4 +64,8 @@ extension ErrorCode.Code {
     var stringValue: String {
         return Terminal.stringFromError(self)
     }
+}
+
+func rejectStripeError(_ error: StripeError, using reject: @escaping RCTPromiseRejectBlock) {
+    reject(error.code.rawValue, error.message, nil)
 }

--- a/ios/Errors.swift
+++ b/ios/Errors.swift
@@ -5,17 +5,6 @@ enum CommonErrorType: String {
     case AlreadyDiscovering
 }
 
-enum BridgeCommonError: String {
-  case failed = "Failed"
-  case canceled = "Canceled"
-  case unknown = "Unknown"
-}
-
-struct StripeError {
-    let code: BridgeCommonError
-    let message: String
-}
-
 class Errors {
     class func validateRequiredParameters(params: NSDictionary, requiredParams: [String]) -> String? {
         var invalid: [String] = []
@@ -64,8 +53,4 @@ extension ErrorCode.Code {
     var stringValue: String {
         return Terminal.stringFromError(self)
     }
-}
-
-func rejectStripeError(_ error: StripeError, using reject: @escaping RCTPromiseRejectBlock) {
-    reject(error.code.rawValue, error.message, nil)
 }

--- a/ios/Mappers.swift
+++ b/ios/Mappers.swift
@@ -557,6 +557,24 @@ class Mappers {
         default: return SimulateReaderUpdate.none
         }
     }
+  
+    class func mapToSimulatedCollectInputsResult(_ behavior: String) -> SimulatedCollectInputsResult {
+        let skipBehavior: SimulatedCollectInputsSkipBehavior?
+        switch behavior.lowercased() {
+        case "all": skipBehavior = SimulatedCollectInputsSkipBehavior.all
+        case "none": skipBehavior = SimulatedCollectInputsSkipBehavior.none
+        case "timeout": skipBehavior = nil
+        default: skipBehavior = SimulatedCollectInputsSkipBehavior.none
+        }
+
+        if let successBehavior = skipBehavior {
+          return SimulatedCollectInputsResultSucceeded(
+            simulatedCollectInputsSkipBehavior: successBehavior
+          )
+        } else {
+          return SimulatedCollectInputsResultTimeout()
+        }
+    }
 
     class func mapFromCardPresent(_ cardPresent: CardPresentDetails) -> NSDictionary {
         var receiptDetailsMap: NSDictionary?

--- a/ios/Mappers.swift
+++ b/ios/Mappers.swift
@@ -559,20 +559,21 @@ class Mappers {
     }
   
     class func mapToSimulatedCollectInputsResult(_ behavior: String) -> SimulatedCollectInputsResult {
-        let skipBehavior: SimulatedCollectInputsSkipBehavior?
         switch behavior.lowercased() {
-        case "all": skipBehavior = SimulatedCollectInputsSkipBehavior.all
-        case "none": skipBehavior = SimulatedCollectInputsSkipBehavior.none
-        case "timeout": skipBehavior = nil
-        default: skipBehavior = SimulatedCollectInputsSkipBehavior.none
-        }
-
-        if let successBehavior = skipBehavior {
-          return SimulatedCollectInputsResultSucceeded(
-            simulatedCollectInputsSkipBehavior: successBehavior
-          )
-        } else {
-          return SimulatedCollectInputsResultTimeout()
+        case "all":
+            return SimulatedCollectInputsResultSucceeded(
+                simulatedCollectInputsSkipBehavior: SimulatedCollectInputsSkipBehavior.all
+              )
+        case "none":
+            return SimulatedCollectInputsResultSucceeded(
+                simulatedCollectInputsSkipBehavior: SimulatedCollectInputsSkipBehavior.none
+              )
+        case "timeout":
+            return SimulatedCollectInputsResultTimeout()
+        default:
+            return SimulatedCollectInputsResultSucceeded(
+                simulatedCollectInputsSkipBehavior: SimulatedCollectInputsSkipBehavior.none
+              )
         }
     }
 

--- a/ios/StripeTerminalReactNative.m
+++ b/ios/StripeTerminalReactNative.m
@@ -154,6 +154,12 @@ RCT_EXTERN_METHOD(
                   )
 
 RCT_EXTERN_METHOD(
+                  setSimulatedCollectInputsResult:(NSString *)behavior
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject
+                  )
+
+RCT_EXTERN_METHOD(
                   collectRefundPaymentMethod:(NSDictionary *)params
                   resolver: (RCTPromiseResolveBlock)resolve
                   rejecter: (RCTPromiseRejectBlock)reject

--- a/ios/StripeTerminalReactNative.swift
+++ b/ios/StripeTerminalReactNative.swift
@@ -220,6 +220,24 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, MobileReade
         Terminal.shared.simulatorConfiguration.offlineEnabled = simulatedOffline;
         resolve([:])
     }
+  
+  
+    @objc(setSimulatedCollectInputsResult:resolver:rejecter:)
+    func setSimulatedCollectInputsResult(
+      _ behavior: String,
+      resolver resolve: @escaping RCTPromiseResolveBlock,
+      rejecter reject: @escaping RCTPromiseRejectBlock
+    ) {
+        let allowedValues = ["all", "none", "timeout"]
+        if !allowedValues.contains(behavior.lowercased()) {
+          rejectStripeError(StripeError(code: BridgeCommonError.failed, message: "You must provide \(allowedValues) parameters."), using: reject)
+            return
+        }
+      
+        let result: SimulatedCollectInputsResult = Mappers.mapToSimulatedCollectInputsResult(behavior)
+        Terminal.shared.simulatorConfiguration.simulatedCollectInputsResult = result
+        resolve([:])
+    }
 
     @objc(setConnectionToken:resolver:rejecter:)
     func setConnectionToken(params: NSDictionary, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
@@ -243,7 +261,7 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, MobileReade
             config = try Mappers.mapToDiscoveryConfiguration(discoveryMethod, simulated: simulated ?? false,  locationId: locationId ?? nil, timeout: timeout)
         } catch {
             resolve(Errors.createError(nsError: error as NSError))
-            return
+          return
         }
 
         guard discoverCancelable == nil else {

--- a/ios/StripeTerminalReactNative.swift
+++ b/ios/StripeTerminalReactNative.swift
@@ -230,7 +230,7 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, MobileReade
     ) {
         let allowedValues = ["all", "none", "timeout"]
         if !allowedValues.contains(behavior.lowercased()) {
-          rejectStripeError(StripeError(code: BridgeCommonError.failed, message: "You must provide \(allowedValues) parameters."), using: reject)
+            reject("Failed", "You must provide \(allowedValues) parameters.", nil)
             return
         }
       

--- a/ios/Tests/MappersTests.swift
+++ b/ios/Tests/MappersTests.swift
@@ -215,6 +215,29 @@ final class MappersTests: XCTestCase {
             }
         }
     }
+  
+    func testMapToSimulatedCollectInputsResultBehaviors() {
+          let testCases: [(input: String, expectedSucceeded: SimulatedCollectInputsSkipBehavior?)] = [
+                  ("all", .all),
+                  ("none", SimulatedCollectInputsSkipBehavior.none),
+                  ("timeout", nil),
+                  ("invalid", SimulatedCollectInputsSkipBehavior.none)
+          ]
+
+          for (input, expectedBehavior) in testCases {
+              let result = Mappers.mapToSimulatedCollectInputsResult(input)
+
+              if let expected = expectedBehavior {
+                  guard let succeeded = result as? SimulatedCollectInputsResultSucceeded else {
+                      XCTFail("Expected SimulatedCollectInputsResultSucceeded for input '\(input)'")
+                      continue
+                  }
+                  XCTAssertEqual(succeeded.simulatedCollectInputsSkipBehavior, expected, "Wrong skipBehavior for input '\(input)'")
+              } else {
+                  XCTAssertTrue(result is SimulatedCollectInputsResultTimeout, "Expected SimulatedCollectInputsResultTimeout for input '\(input)'")
+              }
+          }
+    }
 }
 
 struct TestableTextResult : stripe_terminal_react_native.TextResult {

--- a/src/StripeTerminalSdk.tsx
+++ b/src/StripeTerminalSdk.tsx
@@ -146,7 +146,7 @@ export interface StripeTerminalSdkType {
   setSimulatedOfflineMode(simulatedOffline: boolean): Promise<{
     error?: StripeError;
     }>;
-  setSimulatedCollectInputsResult(simulatedCollectInputsSkipBehavior: string): Promise<{
+  setSimulatedCollectInputsResult(simulatedCollectInputsBehavior: string): Promise<{
     error?: StripeError;
   }>;
   getOfflineStatus(): Promise<OfflineStatus>;

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -593,18 +593,18 @@ export async function setSimulatedOfflineMode(
 }
 
 export async function setSimulatedCollectInputsResult(
-  simulatedCollectInputsSkipBehavior: string
+  simulatedCollectInputsBehavior: string
 ): Promise<{ error?: StripeError }> {
   return Logger.traceSdkMethod(async () => {
     try {
-      await StripeTerminalSdk.setSimulatedCollectInputsResult(simulatedCollectInputsSkipBehavior);
+      await StripeTerminalSdk.setSimulatedCollectInputsResult(simulatedCollectInputsBehavior);
       return {};
     } catch (error) {
       return {
         error: error as any,
       };
     }
-  }, 'setSimulatedCollectInputsResult')(simulatedCollectInputsSkipBehavior);
+  }, 'setSimulatedCollectInputsResult')(simulatedCollectInputsBehavior);
 }
 
 export async function collectRefundPaymentMethod(

--- a/src/hooks/useStripeTerminal.tsx
+++ b/src/hooks/useStripeTerminal.tsx
@@ -741,14 +741,14 @@ export function useStripeTerminal(props?: Props) {
   );
 
   const _setSimulatedCollectInputsResult = useCallback(
-    async (simulatedCollectInputsSkipBehavior: string) => {
+    async (simulatedCollectInputsBehavior: string) => {
       if (!_isInitialized()) {
         console.error(NOT_INITIALIZED_ERROR_MESSAGE);
         throw Error(NOT_INITIALIZED_ERROR_MESSAGE);
       }
       setLoading(true);
 
-      const response = await setSimulatedCollectInputsResult(simulatedCollectInputsSkipBehavior);
+      const response = await setSimulatedCollectInputsResult(simulatedCollectInputsBehavior);
       setLoading(false);
 
       return response;

--- a/stripe-terminal-react-native.podspec
+++ b/stripe-terminal-react-native.podspec
@@ -21,5 +21,5 @@ Pod::Spec.new do |s|
   end
 
   s.dependency 'React-Core'
-  s.dependency 'StripeTerminal', '~> 4.3.0'
+  s.dependency 'StripeTerminal', '~> 4.4.0'
 end


### PR DESCRIPTION
## Summary

Add simulated Internet reader support for collecting inputs on iOS side

## Motivation

We are upgrading the functionality of iOS SDK 4.4. This PR is a function of it.
**bugfix**: Add the missing timeout scenario to Android side.

## Testing

- [x] I tested this manually
- [x] I added automated tests, only a part of unit test

1. Check the `simulated toggle button` and Discovery Method should be `internet`.
Then discover reader and choose one.
<img width="447" alt="step 1" src="https://github.com/user-attachments/assets/33abd610-3d90-490d-b920-99d174a62b8f" />

2. Click `collect payment`
<img width="461" alt="step 2" src="https://github.com/user-attachments/assets/13c3bdbb-1b13-41be-8f4c-e870df3c5307" />

3. We have three scenarios `["none", "all" "timeout"]`
    1.  Successful input collection without skipping any inputs
    2. Successful input collection with skipping all non-required inputs
    3. Failed input collection because of a timeout
    
  choose one and click `Phone,  email,  numeric, and text forms`
<img width="448" alt="step 3" src="https://github.com/user-attachments/assets/8728445f-59df-4187-ac5a-449b0f76bc6e" />

4. Check the result
<img width="460" alt="step 4" src="https://github.com/user-attachments/assets/646c31a9-0d71-4833-bf71-0ba71193f7c9" />

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
