### PR TITLE
Bump Android native SDK to 4.4

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,7 +28,7 @@ def getExtOrIntegerDefault(name) {
     return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties['StripeTerminalReactNative_' + name]).toInteger()
 }
 
-def terminalAndroidSdkVersion = '4.3.1'
+def terminalAndroidSdkVersion = '4.4.0'
 def reactNativeSdkVersion = getVersionFromNpm()
 
 android {

--- a/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
@@ -149,42 +149,53 @@ internal fun mapFromNetworkStatus(status: Reader.NetworkStatus?): String {
 
 internal fun mapFromDeviceType(type: DeviceType): String {
     return when (type) {
-        DeviceType.CHIPPER_1X -> "chipper1X"
-        DeviceType.CHIPPER_2X -> "chipper2X"
-        DeviceType.ETNA -> "etna"
-        DeviceType.STRIPE_M2 -> "stripeM2"
-        DeviceType.STRIPE_S700 -> "stripeS700"
-        DeviceType.STRIPE_S700_DEVKIT -> "stripeS700Devkit"
-        DeviceType.STRIPE_S710 -> "stripeS710"
-        DeviceType.STRIPE_S710_DEVKIT -> "stripeS710Devkit"
-        DeviceType.UNKNOWN -> "unknown"
-        DeviceType.VERIFONE_P400 -> "verifoneP400"
-        DeviceType.WISECUBE -> "wiseCube"
-        DeviceType.WISEPAD_3 -> "wisePad3"
-        DeviceType.WISEPAD_3S -> "wisePad3s"
-        DeviceType.WISEPOS_E -> "wisePosE"
-        DeviceType.WISEPOS_E_DEVKIT -> "wisePosEDevkit"
-        DeviceType.TAP_TO_PAY_DEVICE -> "tapToPay"
+        DeviceType.CHIPPER_1X -> DeviceSerialName.CHIPPER_1X.serialName
+        DeviceType.CHIPPER_2X -> DeviceSerialName.CHIPPER_2X.serialName
+        DeviceType.ETNA -> DeviceSerialName.ETNA.serialName
+        DeviceType.STRIPE_M2 -> DeviceSerialName.STRIPE_M2.serialName
+        DeviceType.STRIPE_S700 -> DeviceSerialName.STRIPE_S700.serialName
+        DeviceType.STRIPE_S700_DEVKIT -> DeviceSerialName.STRIPE_S700_DEVKIT.serialName
+        DeviceType.STRIPE_S710 -> DeviceSerialName.STRIPE_S710.serialName
+        DeviceType.STRIPE_S710_DEVKIT -> DeviceSerialName.STRIPE_S710_DEVKIT.serialName
+        DeviceType.UNKNOWN -> DeviceSerialName.UNKNOWN.serialName
+        DeviceType.VERIFONE_P400 -> DeviceSerialName.VERIFONE_P400.serialName
+        DeviceType.WISECUBE -> DeviceSerialName.WISECUBE.serialName
+        DeviceType.WISEPAD_3 -> DeviceSerialName.WISEPAD_3.serialName
+        DeviceType.WISEPAD_3S -> DeviceSerialName.WISEPAD_3S.serialName
+        DeviceType.WISEPOS_E -> DeviceSerialName.WISEPOS_E.serialName
+        DeviceType.WISEPOS_E_DEVKIT -> DeviceSerialName.WISEPOS_E_DEVKIT.serialName
+        DeviceType.TAP_TO_PAY_DEVICE -> DeviceSerialName.TAP_TO_PAY_DEVICE.serialName
+        DeviceType.VERIFONE_V660P -> DeviceSerialName.VERIFONE_V660P.serialName
+        DeviceType.VERIFONE_M425 -> DeviceSerialName.VERIFONE_M425.serialName
+        DeviceType.VERIFONE_M450 -> DeviceSerialName.VERIFONE_M450.serialName
+        DeviceType.VERIFONE_P630 -> DeviceSerialName.VERIFONE_P630.serialName
+        DeviceType.VERIFONE_UX700 -> DeviceSerialName.VERIFONE_UX700.serialName
     }
 }
 
 internal fun mapToDeviceType(type: String): DeviceType? {
-    return when (type) {
-        "chipper1X" -> DeviceType.CHIPPER_1X
-        "chipper2X" -> DeviceType.CHIPPER_2X
-        "etna" -> DeviceType.ETNA
-        "stripeM2" -> DeviceType.STRIPE_M2
-        "stripeS700" -> DeviceType.STRIPE_S700
-        "stripeS700Devkit" -> DeviceType.STRIPE_S700_DEVKIT
-        "stripeS710" -> DeviceType.STRIPE_S710
-        "stripeS710Devkit" -> DeviceType.STRIPE_S710_DEVKIT
-        "verifoneP400" -> DeviceType.VERIFONE_P400
-        "wiseCube" -> DeviceType.WISECUBE
-        "wisePad3" -> DeviceType.WISEPAD_3
-        "wisePad3s" -> DeviceType.WISEPAD_3S
-        "wisePosE" -> DeviceType.WISEPOS_E
-        "wisePosEDevkit" -> DeviceType.WISEPOS_E_DEVKIT
-        "tapToPay" -> DeviceType.TAP_TO_PAY_DEVICE
+    val deviceSerialName = DeviceSerialName.fromSerialName(type)
+    return when (deviceSerialName) {
+        DeviceSerialName.CHIPPER_1X -> DeviceType.CHIPPER_1X
+        DeviceSerialName.CHIPPER_2X -> DeviceType.CHIPPER_2X
+        DeviceSerialName.ETNA -> DeviceType.ETNA
+        DeviceSerialName.STRIPE_M2 -> DeviceType.STRIPE_M2
+        DeviceSerialName.STRIPE_S700 -> DeviceType.STRIPE_S700
+        DeviceSerialName.STRIPE_S700_DEVKIT -> DeviceType.STRIPE_S700_DEVKIT
+        DeviceSerialName.STRIPE_S710 -> DeviceType.STRIPE_S710
+        DeviceSerialName.STRIPE_S710_DEVKIT -> DeviceType.STRIPE_S710_DEVKIT
+        DeviceSerialName.VERIFONE_P400 -> DeviceType.VERIFONE_P400
+        DeviceSerialName.WISECUBE -> DeviceType.WISECUBE
+        DeviceSerialName.WISEPAD_3 -> DeviceType.WISEPAD_3
+        DeviceSerialName.WISEPAD_3S -> DeviceType.WISEPAD_3S
+        DeviceSerialName.WISEPOS_E -> DeviceType.WISEPOS_E
+        DeviceSerialName.WISEPOS_E_DEVKIT -> DeviceType.WISEPOS_E_DEVKIT
+        DeviceSerialName.TAP_TO_PAY_DEVICE -> DeviceType.TAP_TO_PAY_DEVICE
+        DeviceSerialName.VERIFONE_V660P -> DeviceType.VERIFONE_V660P
+        DeviceSerialName.VERIFONE_M425 -> DeviceType.VERIFONE_M425
+        DeviceSerialName.VERIFONE_M450 -> DeviceType.VERIFONE_M450
+        DeviceSerialName.VERIFONE_P630 -> DeviceType.VERIFONE_P630
+        DeviceSerialName.VERIFONE_UX700 -> DeviceType.VERIFONE_UX700
         else -> null
     }
 }

--- a/android/src/main/java/com/stripeterminalreactnative/ReactNativeConstants.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/ReactNativeConstants.kt
@@ -23,3 +23,33 @@ enum class ReactNativeConstants(val listenerName: String) {
     REPORT_LOW_BATTERY_WARNING("didReportLowBatteryWarning"),
     REPORT_READER_EVENT("didReportReaderEvent"),
 }
+
+enum class DeviceSerialName(val serialName: String) {
+    CHIPPER_1X("chipper1X"),
+    CHIPPER_2X("chipper2X"),
+    ETNA("etna"),
+    STRIPE_M2("stripeM2"),
+    STRIPE_S700("stripeS700"),
+    STRIPE_S700_DEVKIT("stripeS700Devkit"),
+    STRIPE_S710("stripeS710"),
+    STRIPE_S710_DEVKIT("stripeS710Devkit"),
+    UNKNOWN("unknown"),
+    VERIFONE_P400("verifoneP400"),
+    WISECUBE("wiseCube"),
+    WISEPAD_3("wisePad3"),
+    WISEPAD_3S("wisePad3s"),
+    WISEPOS_E("wisePosE"),
+    WISEPOS_E_DEVKIT("wisePosEDevkit"),
+    TAP_TO_PAY_DEVICE("tapToPay"),
+    VERIFONE_V660P("verifoneV660P"),
+    VERIFONE_M425("verifoneM425"),
+    VERIFONE_M450("verifoneM450"),
+    VERIFONE_P630("verifoneP630"),
+    VERIFONE_UX700("verifoneUX700");
+
+    companion object {
+        private val serialNames = DeviceSerialName.entries.associateBy(DeviceSerialName::serialName)
+
+        fun fromSerialName(serialName: String): DeviceSerialName? = serialNames[serialName]
+    }
+}


### PR DESCRIPTION
## Summary

Bump the Android native SDK version to 4.4 and update the related code

## Motivation

We are working on the native SDKs 4.4 upgrade.
Because the Android native SDK has 1 exposing enum change, I want an independent PR for the bumping version of the Android native SDK.

- Extract the hardcode Device Strings to an `enum` for better style.

## Testing

- [X] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [X] This PR does not result in any developer-facing changes.
