### PR TITLE
Add new reader disconnect reasons from Android & iOS native SDK v4.4

### DIFF
--- a/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
@@ -892,6 +892,8 @@ fun mapFromReaderDisconnectReason(reason: DisconnectReason): String {
         DisconnectReason.CRITICALLY_LOW_BATTERY -> "criticallyLowBattery"
         DisconnectReason.POWERED_OFF -> "poweredOff"
         DisconnectReason.BLUETOOTH_DISABLED -> "bluetoothDisabled"
+        DisconnectReason.USB_DISCONNECTED -> "usbDisconnected"
+        DisconnectReason.IDLE_POWER_DOWN -> "idlePowerDown"
         else -> {
             "unknown"
         }

--- a/ios/Mappers.swift
+++ b/ios/Mappers.swift
@@ -945,6 +945,9 @@ class Mappers {
         case DisconnectReason.criticallyLowBattery: return "criticallyLowBattery"
         case DisconnectReason.poweredOff: return "poweredOff"
         case DisconnectReason.bluetoothDisabled: return "bluetoothDisabled"
+        case DisconnectReason.bluetoothSignalLost: return "bluetoothSignalLost"
+        case DisconnectReason.usbDisconnected: return "usbDisconnected"
+        case DisconnectReason.idlePowerDown: return "idlePowerDown"
         default: return "unknown"
         }
     }

--- a/src/types/Reader.ts
+++ b/src/types/Reader.ts
@@ -130,6 +130,9 @@ export namespace Reader {
     | 'criticallyLowBattery'
     | 'poweredOff'
     | 'bluetoothDisabled'
+    | 'bluetoothSignalLost'
+    | 'usbDisconnected'
+    | 'idlePowerDown'
     | 'unknown';
 
   export type ReaderSettings =


### PR DESCRIPTION
## Summary

We are updating the native SDKs to 4.4. And this PR is a new feature in the upgrade.

## Motivation

iOS
- Added new mobile reader disconnect reasons: bluetoothSignalLost, usbDisconnected, and idlePowerDown to [SCPDisconnectReason](https://stripe.dev/stripe-terminal-ios/docs/Enums/SCPDisconnectReason.html).

Android: 

- Improved visibility into mobile reader disconnects by exposing new disconnect reasons: [DisconnectReason.USB_DISCONNECTED](https://stripe.dev/stripe-terminal-android/external/com.stripe.stripeterminal.external.models/-disconnect-reason/-u-s-b_-d-i-s-c-o-n-n-e-c-t-e-d/index.html), and [DisconnectReason.IDLE_POWER_DOWN](https://stripe.dev/stripe-terminal-android/external/com.stripe.stripeterminal.external.models/-disconnect-reason/-i-d-l-e_-p-o-w-e-r_-d-o-w-n/index.html).

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [X] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [X] This PR does not result in any developer-facing changes.
