### PR TITLE
Fix amount surcharge not being passed through to the reader confirm request

### DIFF
--- a/ios/StripeTerminalReactNative.swift
+++ b/ios/StripeTerminalReactNative.swift
@@ -635,6 +635,9 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, MobileReade
                 }
                 resolve(result)
             } else if let paymentIntent = pi {
+                // Always store the latest instance of the PaymentIntent so we pass the latest instance back in
+                // to the confirm call.
+                self.paymentIntents[uuid] = paymentIntent
                 let paymentIntent = Mappers.mapFromPaymentIntent(paymentIntent, uuid: uuid)
                 resolve(["paymentIntent": paymentIntent])
             }


### PR DESCRIPTION
## Summary
The `PaymentIntent` instance returned from the `collectPaymentMethod` is the updated API response instance. The native SDK expects that updated instance and currently won't pass through the confirmConfig values if that instance isn't the one passed in to the confirmRequest (being improved separately).

<!-- Simple summary of what was changed. -->

## Motivation
Fix bug where surcharge amount wasn't passed through to the confirm request
https://jira.corp.stripe.com/browse/TERMINAL-46232

<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
manually confirmed amount surcharge is passed through to the reader and the API

- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
