### PR TITLE
Add TapToPay processing check to the Android module

### DIFF
--- a/android/src/main/java/com/stripeterminalreactnative/TapToPay.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/TapToPay.kt
@@ -23,6 +23,7 @@ class TapToPay internal constructor() {
          *
          * @return `true` if the current process is the the dedicated Tap to Pay process, and `false` otherwise.
          */
+        @JvmStatic
         fun isInTapToPayProcess(): Boolean {
             return StripeTerminalTapToPay.isInTapToPayProcess()
         }

--- a/android/src/main/java/com/stripeterminalreactnative/TapToPay.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/TapToPay.kt
@@ -1,0 +1,30 @@
+package com.stripeterminalreactnative
+
+import android.app.Application
+import com.stripe.stripeterminal.taptopay.TapToPay as StripeTerminalTapToPay
+
+/**
+ *
+ * This is the top-level class delegating Stripe Terminal Tap to Pay Android SDK.
+ *
+ */
+class TapToPay internal constructor() {
+
+    companion object {
+
+        /**
+         * Return whether or not the current process is the dedicated Tap to Pay process.
+         *
+         * Tap to Pay operates within a dedicated process, a second instance of your application, to
+         * ensure the secure handling of payment data. As a result, the client
+         * app's [Application] subclass will be initialized within this process as well. Given that certain operations may be
+         * incompatible in this process, this method can be utilized to determine whether the application should skip those
+         * operations at all.
+         *
+         * @return `true` if the current process is the the dedicated Tap to Pay process, and `false` otherwise.
+         */
+        fun isInTapToPayProcess(): Boolean {
+            return StripeTerminalTapToPay.isInTapToPayProcess()
+        }
+    }
+}

--- a/dev-app/android/app/src/main/java/com/dev/app/stripeterminalreactnative/MainApplication.kt
+++ b/dev-app/android/app/src/main/java/com/dev/app/stripeterminalreactnative/MainApplication.kt
@@ -1,7 +1,6 @@
 package com.dev.app.stripeterminalreactnative
 
 import android.app.Application
-import android.util.Log
 import com.facebook.react.PackageList
 import com.facebook.react.ReactApplication
 import com.facebook.react.ReactHost
@@ -40,7 +39,7 @@ class MainApplication : Application(), ReactApplication {
     override fun onCreate() {
         super.onCreate()
         // Skip initialization if running in the TTPA process.
-        if (TapToPay.isInTapToPayProcess().also { Log.d("FATT", "isInTapToPayProcess: $it") }) { return }
+        if (TapToPay.isInTapToPayProcess()) { return }
 
         TerminalApplicationDelegate.onCreate(this)
         SoLoader.init(this, OpenSourceMergedSoMapping)

--- a/dev-app/android/app/src/main/java/com/dev/app/stripeterminalreactnative/MainApplication.kt
+++ b/dev-app/android/app/src/main/java/com/dev/app/stripeterminalreactnative/MainApplication.kt
@@ -1,6 +1,7 @@
 package com.dev.app.stripeterminalreactnative
 
 import android.app.Application
+import android.util.Log
 import com.facebook.react.PackageList
 import com.facebook.react.ReactApplication
 import com.facebook.react.ReactHost
@@ -12,6 +13,7 @@ import com.facebook.react.defaults.DefaultReactNativeHost
 import com.facebook.react.soloader.OpenSourceMergedSoMapping
 import com.facebook.soloader.SoLoader
 import com.stripeterminalreactnative.StripeTerminalReactNativePackage
+import com.stripeterminalreactnative.TapToPay
 import com.stripeterminalreactnative.TerminalApplicationDelegate
 
 class MainApplication : Application(), ReactApplication {
@@ -37,7 +39,10 @@ class MainApplication : Application(), ReactApplication {
 
     override fun onCreate() {
         super.onCreate()
-        TerminalApplicationDelegate.onCreate(this);
+        // Skip initialization if running in the TTPA process.
+        if (TapToPay.isInTapToPayProcess().also { Log.d("FATT", "isInTapToPayProcess: $it") }) { return }
+
+        TerminalApplicationDelegate.onCreate(this)
         SoLoader.init(this, OpenSourceMergedSoMapping)
         if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
             // If you opted-in for the New Architecture, we load the native entry point for this app.


### PR DESCRIPTION
## Summary

Tap to Pay operates within a dedicated process, a second instance of your application, to ensure the secure handling of payment data. As a result, the client app's Application subclass will also be initialized within this process. Given that certain operations in the application class may be incompatible in this process, checking if the device is processing Tap To Pay can be utilized to determine whether the application should skip those operations at all.

## Motivation

Android native SDK 4.4 has this new checking, so we want to have it in the React Native SDK, too.

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [X] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [X] This PR does not result in any developer-facing changes.
