### PR TITLE
Expose client secret in payment intent on Android side

### DIFF
--- a/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
@@ -245,6 +245,7 @@ internal fun mapFromPaymentIntent(paymentIntent: PaymentIntent, uuid: String): R
         putInt("amount", paymentIntent.amount.toInt())
         putString("captureMethod", paymentIntent.captureMethod)
         putArray("charges", mapFromChargesList(paymentIntent.getCharges()))
+        putString("clientSecret", paymentIntent.clientSecret)
         putString("created", convertToUnixTimestamp(paymentIntent.created))
         putString("currency", paymentIntent.currency)
         putMap(

--- a/dev-app/src/screens/CollectCardPaymentScreen.tsx
+++ b/dev-app/src/screens/CollectCardPaymentScreen.tsx
@@ -356,7 +356,7 @@ export default function CollectCardPaymentScreen() {
           name: 'Created',
           description: 'terminal.createPaymentIntent',
           onBack: cancelCollectPaymentMethod,
-          metadata: { paymentIntentId: paymentIntent.id },
+          metadata: { paymentIntentId: paymentIntent.id, paymentIntent: JSON.stringify(paymentIntent, null, 2) },
         },
       ],
     });

--- a/src/types/PaymentIntent.ts
+++ b/src/types/PaymentIntent.ts
@@ -7,8 +7,8 @@ export namespace PaymentIntent {
     amountDetails: AmountDetails;
     amountTip: number;
     captureMethod: string;
-    clientSecret: string;
     charges: Charge[];
+    clientSecret: string;
     created: string;
     currency: string;
     statementDescriptor: string;

--- a/src/types/PaymentIntent.ts
+++ b/src/types/PaymentIntent.ts
@@ -7,6 +7,7 @@ export namespace PaymentIntent {
     amountDetails: AmountDetails;
     amountTip: number;
     captureMethod: string;
+    clientSecret: string;
     charges: Charge[];
     created: string;
     currency: string;


### PR DESCRIPTION
## Summary

Add a new filed `clientSecret` to Payment Intent.

## Motivation

Stripe provides client_secret in payment intent, which was created by Android native SDK. This PR is to eliminate the gap between RN and Android SDK. 

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [X] I tested this manually
- [ ] I added automated tests
<img width="455" alt="New payment intent structure" src="https://github.com/user-attachments/assets/6077f66f-e9c7-4d9a-8de4-0a55c0f94e2b" />

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [X] This PR does not result in any developer-facing changes.
