### PR TITLE
Fix the display logic of disconnect dialog in dev-app

### DIFF
--- a/dev-app/src/components/AlertDialog.tsx
+++ b/dev-app/src/components/AlertDialog.tsx
@@ -18,11 +18,13 @@ export default function AlertDialog({
   title,
   message,
   buttons,
+  onDismiss = () => {},
 }: {
   visible: boolean;
   title: string;
   message?: string;
   buttons?: AlertButton[];
+  onDismiss?: () => void;
 }) {
   const androidDefaults = {
     container: {
@@ -101,7 +103,7 @@ export default function AlertDialog({
             if (index === 0) defaultButtonText = 'ASK ME LATER';
             else if (index === 1) defaultButtonText = 'CANCEL';
           } else if (buttons.length === 2 && index === 0)
-            defaultButtonText = 'CANCEL';
+            {defaultButtonText = 'CANCEL';}
           return (
             <View
               key={index}
@@ -234,14 +236,14 @@ export default function AlertDialog({
       animationType="fade"
       transparent={true}
       visible={visible}
-      onRequestClose={() => {}}
+      onRequestClose={onDismiss}
     >
       <Pressable
         style={[
           Platform.OS === 'ios' ? styles.iOSBackdrop : styles.androidBackdrop,
           styles.backdrop,
         ]}
-        onPress={() => {}}
+        onPress={onDismiss}
       />
       <View style={styles.alertBox}>
         {Platform.OS === 'ios' ? (

--- a/dev-app/src/screens/HomeScreen.tsx
+++ b/dev-app/src/screens/HomeScreen.tsx
@@ -59,7 +59,6 @@ export default function HomeScreen() {
     const handleAppStateChange = (nextAppState: AppStateStatus) => {
       if (appState.current.match(/inactive|background/) && nextAppState === 'active') {
         setAppIsActive(true);
-
       } else if (nextAppState !== 'active') {
         setAppIsActive(false);
       }
@@ -320,19 +319,6 @@ export default function HomeScreen() {
           },
         ]}
       />
-
-      <AlertDialog
-        visible={appIsActive && showDisconnectAlert.visible}
-        title="Reader disconnected!"
-        message= {`${showDisconnectAlert.reason}`}
-        onDismiss={() => setShowDisconnectAlert({ visible: false })}
-        buttons={[
-          {
-            text: 'Dismiss',
-            onPress: () => setShowDisconnectAlert({ visible: false }),
-          },
-        ]}
-      />
     </>
   );
   return (
@@ -513,6 +499,19 @@ export default function HomeScreen() {
               }
             />
           </List>
+
+          <AlertDialog
+            visible={appIsActive && showDisconnectAlert.visible}
+            title="Reader disconnected!"
+            message= {`${showDisconnectAlert.reason}`}
+            onDismiss={() => setShowDisconnectAlert({ visible: false })}
+            buttons={[
+              {
+                text: 'Dismiss',
+                onPress: () => setShowDisconnectAlert({ visible: false }),
+              },
+            ]}
+          />
         </>
       )}
     </KeyboardAwareScrollView>

--- a/dev-app/src/screens/HomeScreen.tsx
+++ b/dev-app/src/screens/HomeScreen.tsx
@@ -322,199 +322,201 @@ export default function HomeScreen() {
     </>
   );
   return (
-    <KeyboardAwareScrollView
-      testID="home-screen"
-      style={styles.container}
-      contentInsetAdjustmentBehavior="automatic"
-    >
-      <View style={styles.accountContainer}>
-        <Text style={styles.readerName}>
-          {account?.settings?.dashboard?.display_name} ({account?.id})
-        </Text>
-        {account && (
-          <View
-            testID="online-indicator"
-            style={[
-              styles.indicator,
-              { backgroundColor: online ? colors.green : colors.red },
-            ]}
-          />
-        )}
-      </View>
-      {connectedReader ? (
-        <View style={styles.connectedReaderContainer}>
+    <React.Fragment>
+      <KeyboardAwareScrollView
+        testID="home-screen"
+        style={styles.container}
+        contentInsetAdjustmentBehavior="automatic"
+      >
+        <View style={styles.accountContainer}>
+          <Text style={styles.readerName}>
+            {account?.settings?.dashboard?.display_name} ({account?.id})
+          </Text>
+          {account && (
+            <View
+              testID="online-indicator"
+              style={[
+                styles.indicator,
+                { backgroundColor: online ? colors.green : colors.red },
+              ]}
+            />
+          )}
+        </View>
+        {connectedReader ? (
+          <View style={styles.connectedReaderContainer}>
+            <View style={styles.imageContainer}>
+              <Image source={icon} style={styles.image} />
+            </View>
+
+            <Text style={styles.readerName}>{deviceType}</Text>
+            <Text style={styles.connectionStatus}>
+              {connectionStatus} {simulated && <Text>, simulated</Text>}
+            </Text>
+            <Text style={styles.connectionStatus}>
+              {batteryStatus} {chargingStatus}
+            </Text>
+          </View>
+        ) : (
           <View style={styles.imageContainer}>
             <Image source={icon} style={styles.image} />
           </View>
+        )}
 
-          <Text style={styles.readerName}>{deviceType}</Text>
-          <Text style={styles.connectionStatus}>
-            {connectionStatus} {simulated && <Text>, simulated</Text>}
-          </Text>
-          <Text style={styles.connectionStatus}>
-            {batteryStatus} {chargingStatus}
-          </Text>
-        </View>
-      ) : (
-        <View style={styles.imageContainer}>
-          <Image source={icon} style={styles.image} />
-        </View>
-      )}
+        {connectedReader ? (
+          renderConnectedContent
+        ) : (
+          <>
+            <List topSpacing={false} title="MERCHANT SELECTION">
+              <ListItem
+                title="Set Merchant"
+                color={colors.blue}
+                onPress={() => {
+                  navigation.navigate('MerchantSelectScreen', {});
+                }}
+              />
+              <ListItem
+                testID='discover-readers-button'
+                title="Discover Readers"
+                color={colors.blue}
+                disabled={!account}
+                onPress={() => {
+                  const timeout = validTimeoutMethod() ? discoveryTimeout : 0;
+                  navigation.navigate('DiscoverReadersScreen', {
+                    simulated,
+                    discoveryMethod,
+                    discoveryTimeout: timeout,
+                    setPendingUpdateInfo: (update: Reader.SoftwareUpdate | null) => {
+                      setPendingUpdate(update);
+                    },
+                  });
+                }}
+              />
 
-      {connectedReader ? (
-        renderConnectedContent
-      ) : (
-        <>
-          <List topSpacing={false} title="MERCHANT SELECTION">
-            <ListItem
-              title="Set Merchant"
-              color={colors.blue}
-              onPress={() => {
-                navigation.navigate('MerchantSelectScreen', {});
-              }}
-            />
-            <ListItem
-              testID='discover-readers-button'
-              title="Discover Readers"
-              color={colors.blue}
-              disabled={!account}
-              onPress={() => {
-                const timeout = validTimeoutMethod() ? discoveryTimeout : 0;
-                navigation.navigate('DiscoverReadersScreen', {
-                  simulated,
-                  discoveryMethod,
-                  discoveryTimeout: timeout,
-                  setPendingUpdateInfo: (update: Reader.SoftwareUpdate | null) => {
-                    setPendingUpdate(update);
-                  },
-                });
-              }}
-            />
+              <ListItem
+                title="Register Internet Reader"
+                disabled={!account}
+                color={colors.blue}
+                onPress={() => {
+                  navigation.navigate('RegisterInternetReaderScreen', {});
+                }}
+              />
+            </List>
 
-            <ListItem
-              title="Register Internet Reader"
-              disabled={!account}
-              color={colors.blue}
-              onPress={() => {
-                navigation.navigate('RegisterInternetReaderScreen', {});
-              }}
-            />
-          </List>
+            <List topSpacing={false} title="DATABASE">
+              <ListItem
+                title="Database"
+                testID="database"
+                color={colors.blue}
+                onPress={async () => {
+                  navigation.navigate('DatabaseScreen', {});
+                }}
+              />
+            </List>
 
-          <List topSpacing={false} title="DATABASE">
-            <ListItem
-              title="Database"
-              testID="database"
-              color={colors.blue}
-              onPress={async () => {
-                navigation.navigate('DatabaseScreen', {});
-              }}
-            />
-          </List>
+            <List topSpacing={false} title="DISCOVERY METHOD">
+              <ListItem
+                title={mapFromDiscoveryMethod(discoveryMethod)}
+                testID="discovery-method-button"
+                onPress={() =>
+                  navigation.navigate('DiscoveryMethodScreen', {
+                    onChange: async (value: Reader.DiscoveryMethod) => {
+                      await setStoredDiscoveryMethod({
+                        method: value,
+                        isSimulated: simulated,
+                      });
+                      setDiscoveryMethod(value);
+                    },
+                  })
+                }
+              />
+            </List>
 
-          <List topSpacing={false} title="DISCOVERY METHOD">
-            <ListItem
-              title={mapFromDiscoveryMethod(discoveryMethod)}
-              testID="discovery-method-button"
-              onPress={() =>
-                navigation.navigate('DiscoveryMethodScreen', {
-                  onChange: async (value: Reader.DiscoveryMethod) => {
-                    await setStoredDiscoveryMethod({
-                      method: value,
-                      isSimulated: simulated,
-                    });
-                    setDiscoveryMethod(value);
-                  },
-                })
-              }
-            />
-          </List>
+            <List
+              topSpacing={false}
+              title="TIMEOUT"
+              visible={validTimeoutMethod()}
+            >
+              <TextInput
+                keyboardType="numeric"
+                style={styles.input}
+                value={discoveryTimeout !== 0 ? discoveryTimeout.toString() : ''}
+                placeholderTextColor={colors.gray}
+                placeholder="0 => no timeout"
+                onChangeText={(value) => {
+                  const data = parseInt(value, 10) || 0;
+                  setDiscoveryTimeout(data);
+                }}
+              />
+            </List>
 
-          <List
-            topSpacing={false}
-            title="TIMEOUT"
-            visible={validTimeoutMethod()}
-          >
-            <TextInput
-              keyboardType="numeric"
-              style={styles.input}
-              value={discoveryTimeout !== 0 ? discoveryTimeout.toString() : ''}
-              placeholderTextColor={colors.gray}
-              placeholder="0 => no timeout"
-              onChangeText={(value) => {
-                const data = parseInt(value, 10) || 0;
-                setDiscoveryTimeout(data);
-              }}
-            />
-          </List>
+            <List>
+              <ListItem
+                title="Simulated"
+                rightElement={
+                  <Switch
+                    value={simulated}
+                    onValueChange={async (value) => {
+                      await setStoredDiscoveryMethod({
+                        method: discoveryMethod,
+                        isSimulated: value,
+                      });
+                      setSimulated(value);
+                    }}
+                  />
+                }
+              />
 
-          <List>
-            <ListItem
-              title="Simulated"
-              rightElement={
-                <Switch
-                  value={simulated}
-                  onValueChange={async (value) => {
-                    await setStoredDiscoveryMethod({
-                      method: discoveryMethod,
-                      isSimulated: value,
-                    });
-                    setSimulated(value);
-                  }}
-                />
-              }
-            />
+              {simulated ? (<ListItem
+                          title="Simulate Offline Mode"
+                          rightElement={
+                            <Switch
+                            value={simulatedOffline}
+                            onValueChange={async (value) => {
+                              setSimulatedOffline(value);
+                              await setSimulatedOfflineMode(value);
+                            }}
+                            />
+                          }
+                          />) : <></>}
 
-            {simulated ? (<ListItem
-                        title="Simulate Offline Mode"
-                        rightElement={
-                          <Switch
-                          value={simulatedOffline}
-                          onValueChange={async (value) => {
-                            setSimulatedOffline(value);
-                            await setSimulatedOfflineMode(value);
-                          }}
-                          />
-                        }
-                        />) : <></>}
+              <Text style={styles.infoText}>
+                The SDK comes with the ability to simulate behavior without using
+                physical hardware. This makes it easy to quickly test your
+                integration end-to-end, from connecting a reader to taking
+                payments.
+              </Text>
+            </List>
+            <List title="Version">
+              <ListItem
+                title="SDK Version"
+                rightElement={
+                  <Text style={styles.versionText}>{getSdkVersion()}</Text>
+                }
+              />
+              <ListItem
+                title="Native SDK Version"
+                rightElement={
+                  <Text style={styles.versionText}>{innerSdkVersion}</Text>
+                }
+              />
+            </List>
+          </>
+        )}
+      </KeyboardAwareScrollView>
 
-            <Text style={styles.infoText}>
-              The SDK comes with the ability to simulate behavior without using
-              physical hardware. This makes it easy to quickly test your
-              integration end-to-end, from connecting a reader to taking
-              payments.
-            </Text>
-          </List>
-          <List title="Version">
-            <ListItem
-              title="SDK Version"
-              rightElement={
-                <Text style={styles.versionText}>{getSdkVersion()}</Text>
-              }
-            />
-            <ListItem
-              title="Native SDK Version"
-              rightElement={
-                <Text style={styles.versionText}>{innerSdkVersion}</Text>
-              }
-            />
-          </List>
-
-          <AlertDialog
-            visible={appIsActive && showDisconnectAlert.visible}
-            title="Reader disconnected!"
-            message= {`${showDisconnectAlert.reason}`}
-            onDismiss={() => setShowDisconnectAlert({ visible: false })}
-            buttons={[
-              {
-                text: 'Dismiss',
-                onPress: () => setShowDisconnectAlert({ visible: false }),
-              },
-            ]}
-          />
-        </>
-      )}
-    </KeyboardAwareScrollView>
+      <AlertDialog
+        visible={appIsActive && showDisconnectAlert.visible}
+        title="Reader disconnected!"
+        message= {`${showDisconnectAlert.reason}`}
+        onDismiss={() => setShowDisconnectAlert({ visible: false })}
+        buttons={[
+          {
+            text: 'Dismiss',
+            onPress: () => setShowDisconnectAlert({ visible: false }),
+          },
+        ]}
+      />
+    </React.Fragment>
   );
 }
 

--- a/dev-app/src/screens/HomeScreen.tsx
+++ b/dev-app/src/screens/HomeScreen.tsx
@@ -36,8 +36,8 @@ export default function HomeScreen() {
   const [simulated, setSimulated] = useState<boolean>(true);
   const [simulatedOffline, setSimulatedOffline] = useState<boolean>(false);
   const [online, setOnline] = useState<boolean>(true);
-  const [showReconnectAlert, setShowReconnectAlert] = useState<boolean>(false);
-  const [showDisconnectAlert, setShowDisconnectAlert] =
+  const [showReconnectSuccessAlert, setShowReconnectSuccessAlert] = useState<boolean>(false);
+  const [showReconnectingAlert, setShowReconnectingAlert] =
     useState<boolean>(false);
   const [pendingUpdate, setPendingUpdate] =
     useState<Reader.SoftwareUpdate | null>(null);
@@ -112,17 +112,17 @@ export default function HomeScreen() {
     onDidStartReaderReconnect(reason) {
       console.log('onDidStartReaderReconnect ' + reason);
 
-      setShowDisconnectAlert(true);
-      setShowReconnectAlert(false);
+      setShowReconnectingAlert(true);
+      setShowReconnectSuccessAlert(false);
     },
     onDidSucceedReaderReconnect() {
-      setShowReconnectAlert(true);
-      setShowDisconnectAlert(false);
+      setShowReconnectSuccessAlert(true);
+      setShowReconnectingAlert(false);
     },
     onDidFailReaderReconnect() {
       Alert.alert('Reader Disconnected', 'Reader reconnection failed!');
-      setShowDisconnectAlert(false);
-      setShowReconnectAlert(false);
+      setShowReconnectingAlert(false);
+      setShowReconnectSuccessAlert(false);
     },
   });
   useEffect(() => {
@@ -266,14 +266,14 @@ export default function HomeScreen() {
       </List>
 
       <AlertDialog
-        visible={showDisconnectAlert}
+        visible={showReconnectingAlert}
         title="Reconnecting..."
         message="Reader has disconnected."
         buttons={[
           {
             text: 'Cancel',
             onPress: async () => {
-              setShowDisconnectAlert(false);
+              setShowReconnectingAlert(false);
               await cancelReaderReconnection();
             },
           },
@@ -281,14 +281,14 @@ export default function HomeScreen() {
       />
 
       <AlertDialog
-        visible={showReconnectAlert}
+        visible={showReconnectSuccessAlert}
         title="Reconnected!"
         message="We were able to reconnect to the reader."
         buttons={[
           {
             text: 'OK',
             onPress: async () => {
-              setShowReconnectAlert(false);
+              setShowReconnectSuccessAlert(false);
             },
           },
         ]}


### PR DESCRIPTION
## Summary

Fix the display logic of disconnect dialog in dev-app

## Motivation

The disconnect dialog might not pop up in some scenarios. Hence, we want to review and optimize the mechanism of it.

Root cause: when the app receives a disconnect in the background, the dialog will pop up on the “connected screen”, but the component used is the default Alert dialog, which may be ignored by the os when the app is in the background. And after disconnecting, we will go back to “unconnected screen” from “connected screen”, they are different layout.

Solution: Use a custom component and record the state, put the alert dialog in the root of HomeScreen.

New logic: The dialog will be shown every time the reader disconnects. The dialog will not be displayed only when the User triggers a disconnection.

<img width="471" alt="Disconnect dialog" src="https://github.com/user-attachments/assets/641f098d-0e09-44c4-9b5a-404767c3dce7" />

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [X] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [X] This PR does not result in any developer-facing changes.
