### PR TITLE
Bump Android native SDK version to 4.5.1

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -14,7 +14,7 @@ StripeTerminalReactNative_compileSdkVersion=35
 StripeTerminalReactNative_buildToolsVersion=35.0.0
 StripeTerminalReactNative_kotlinVersion=2.0.21
 StripeTerminalReactNative_targetSdkVersion=35
-StripeTerminalReactNative_terminalSdkVersion=4.5.0
+StripeTerminalReactNative_terminalSdkVersion=4.5.1
 StripeTerminalReactNative_taptopay.enabled=true
 android.useAndroidX=true
 


### PR DESCRIPTION
## Summary

In React Native SDK, we will use Android native SDK 4.5.1 and ignore the Android native SDK 4.5.0.

## Motivation

We are aware of some issues in Android native SDK 4.5.0, hence we will use 4.5.1 for the next React Native release.

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [X] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [X] This PR does not result in any developer-facing changes.
