### PR TITLE
[RN SDK Printing] Implement SDK `print` method

### DIFF
--- a/src/StripeTerminalSdk.tsx
+++ b/src/StripeTerminalSdk.tsx
@@ -36,6 +36,7 @@ import type {
   CollectDataResultType,
   TapToPayUxConfiguration,
   ConnectReaderParams,
+  PrintContent,
 } from './types';
 
 const { StripeTerminalReactNative } = NativeModules;
@@ -164,7 +165,7 @@ export interface StripeTerminalSdkType {
     error?: StripeError;
   }>;
   collectData(params: CollectDataParams): Promise<CollectDataResultType>;
-  print(contentUri: string): Promise<{
+  print(content: PrintContent): Promise<{
     error?: StripeError;
   }>;
   cancelReaderReconnection(): Promise<{

--- a/src/StripeTerminalSdk.tsx
+++ b/src/StripeTerminalSdk.tsx
@@ -164,6 +164,9 @@ export interface StripeTerminalSdkType {
     error?: StripeError;
   }>;
   collectData(params: CollectDataParams): Promise<CollectDataResultType>;
+  print(contentUri: string): Promise<{
+    error?: StripeError;
+  }>;
   cancelReaderReconnection(): Promise<{
     error?: StripeError;
   }>;

--- a/src/StripeTerminalSdk.tsx
+++ b/src/StripeTerminalSdk.tsx
@@ -165,6 +165,11 @@ export interface StripeTerminalSdkType {
     error?: StripeError;
   }>;
   collectData(params: CollectDataParams): Promise<CollectDataResultType>;
+  /**
+   * Prints the specified content to the connected reader's printer, if available.
+   * @param content The content to print. Must be an image (JPEG/PNG) encoded as a base64 string or 'data:' URI scheme.
+   * @returns A promise that resolves to an empty object if the print succeeds, or an object containing a `StripeError` if the print fails.
+   */
   print(content: PrintContent): Promise<{
     error?: StripeError;
   }>;

--- a/src/__tests__/__snapshots__/functions.test.ts.snap
+++ b/src/__tests__/__snapshots__/functions.test.ts.snap
@@ -38,6 +38,7 @@ exports[`functions.test.ts Functions snapshot ensure there are no unexpected cha
   "getReaderSettings": [Function],
   "initialize": [Function],
   "installAvailableUpdate": [Function],
+  "print": [Function],
   "rebootReader": [Function],
   "retrievePaymentIntent": [Function],
   "retrieveSetupIntent": [Function],

--- a/src/__tests__/functions.test.ts
+++ b/src/__tests__/functions.test.ts
@@ -115,6 +115,7 @@ describe('functions.test.ts', () => {
           .mockImplementation(() => ({})),
         cancelCollectSetupIntent: jest.fn().mockImplementation(() => ({})),
         setSimulatedCard: jest.fn(),
+        print: jest.fn().mockImplementation(() => ({})),
       }));
     });
 
@@ -321,6 +322,11 @@ describe('functions.test.ts', () => {
       const functions = require('../functions');
       await expect(functions.setSimulatedCard('_number')).resolves.toEqual({});
     });
+
+    it('print returns a proper value', async () => {
+      const functions = require('../functions');
+      await expect(functions.print({} as any)).resolves.toEqual({});
+    });
   });
 
   describe('Functions error results', () => {
@@ -390,6 +396,9 @@ describe('functions.test.ts', () => {
           .fn()
           .mockImplementation(() => ({ error: '_error' })),
         cancelReadReusableCard: jest
+          .fn()
+          .mockImplementation(() => ({ error: '_error' })),
+        print: jest
           .fn()
           .mockImplementation(() => ({ error: '_error' })),
 
@@ -590,6 +599,13 @@ describe('functions.test.ts', () => {
     it('installAvailableUpdate returns a proper value', async () => {
       const functions = require('../functions');
       await expect(functions.installAvailableUpdate()).resolves.toEqual({
+        error: '_error',
+      });
+    });
+
+    it('print returns a proper value', async () => {
+      const functions = require('../functions');
+      await expect(functions.print({} as any)).resolves.toEqual({
         error: '_error',
       });
     });

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -880,6 +880,26 @@ export async function collectData(
   }, 'collectData')();
 }
 
+export async function print(contentUri: string): Promise<{
+  error?: StripeError;
+}> {
+  return Logger.traceSdkMethod(async () => {
+    try {
+      const { error } = await StripeTerminalSdk.print(contentUri);
+      if (error) {
+        return {
+          error,
+        };
+      }
+      return {};
+    } catch (error) {
+      return {
+        error: error as any,
+      };
+    }
+  }, 'print')();
+}
+
 export async function cancelReaderReconnection(): Promise<{
   error?: StripeError;
 }> {

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -37,6 +37,7 @@ import type {
   CollectDataResultType,
   TapToPayUxConfiguration,
   ConnectReaderParams,
+  PrintContent,
 } from './types';
 import { CommonError } from './types';
 import { Platform } from 'react-native';
@@ -880,12 +881,12 @@ export async function collectData(
   }, 'collectData')();
 }
 
-export async function print(contentUri: string): Promise<{
+export async function print(content: PrintContent): Promise<{
   error?: StripeError;
 }> {
   return Logger.traceSdkMethod(async () => {
     try {
-      const { error } = await StripeTerminalSdk.print(contentUri);
+      const { error } = await StripeTerminalSdk.print(content);
       if (error) {
         return {
           error,

--- a/src/hooks/__tests__/__snapshots__/useStripeTerminal.test.tsx.snap
+++ b/src/hooks/__tests__/__snapshots__/useStripeTerminal.test.tsx.snap
@@ -44,6 +44,7 @@ exports[`useStripeTerminal.test.tsx Public API snapshot ensure there are no unex
     "installAvailableUpdate": [Function],
     "isInitialized": false,
     "loading": false,
+    "print": [Function],
     "rebootReader": [Function],
     "retrievePaymentIntent": [Function],
     "retrieveSetupIntent": [Function],

--- a/src/hooks/__tests__/useStripeTerminal.test.tsx
+++ b/src/hooks/__tests__/useStripeTerminal.test.tsx
@@ -146,6 +146,10 @@ function spyAllFunctions({ returnWith = null }: { returnWith?: any } = {}) {
     .spyOn(functions, 'setSimulatedCard')
     .mockImplementation(setSimulatedCard);
 
+  //
+  const print = jest.fn(() => returnWith);
+  jest.spyOn(functions, 'print').mockImplementation(print);
+
   return {
     discoverReaders,
     cancelDiscovering,
@@ -174,6 +178,7 @@ function spyAllFunctions({ returnWith = null }: { returnWith?: any } = {}) {
     cancelCollectRefundPaymentMethod,
     cancelCollectSetupIntent,
     setSimulatedCard,
+    print,
   };
 }
 
@@ -300,6 +305,7 @@ describe('useStripeTerminal.test.tsx', () => {
           result.current.setSimulatedCard('');
           result.current.installAvailableUpdate();
           result.current.setReaderDisplay({} as any);
+          result.current.print({} as any);
           result.current.confirmRefund();
           result.current.cancelCollectSetupIntent();
         } catch (error) {
@@ -348,6 +354,7 @@ describe('useStripeTerminal.test.tsx', () => {
         await result.current.setSimulatedCard('');
         await result.current.installAvailableUpdate();
         await result.current.setReaderDisplay({} as any);
+        await result.current.print({} as any);
         await result.current.confirmRefund();
         await result.current.cancelCollectSetupIntent();
       } catch (error) {
@@ -449,6 +456,7 @@ describe('useStripeTerminal.test.tsx', () => {
       await expect(result.current.setReaderDisplay({} as any)).resolves.toEqual(
         '_value'
       );
+      await expect(result.current.print({} as any)).resolves.toEqual('_value');
       await expect(result.current.confirmRefund()).resolves.toEqual('_value');
       await expect(result.current.cancelCollectSetupIntent()).resolves.toEqual(
         '_value'

--- a/src/hooks/useStripeTerminal.tsx
+++ b/src/hooks/useStripeTerminal.tsx
@@ -28,6 +28,7 @@ import type {
   ConnectTapToPayParams,
   ConnectHandoffParams,
   ConnectInternetReaderParams,
+  PrintContent,
 } from '../types';
 import {
   discoverReaders,
@@ -1009,14 +1010,14 @@ export function useStripeTerminal(props?: Props) {
   );
 
   const _print = useCallback(
-    async (contentUri: string) => {
+    async (content: PrintContent) => {
       if (!_isInitialized()) {
         console.error(NOT_INITIALIZED_ERROR_MESSAGE);
         throw Error(NOT_INITIALIZED_ERROR_MESSAGE);
       }
       setLoading(true);
 
-      const response = await print(contentUri);
+      const response = await print(content);
 
       setLoading(false);
 

--- a/src/hooks/useStripeTerminal.tsx
+++ b/src/hooks/useStripeTerminal.tsx
@@ -69,6 +69,7 @@ import {
   collectInputs,
   cancelCollectInputs,
   collectData,
+  print,
   cancelReaderReconnection,
   supportsReadersOfType,
   getPaymentStatus,
@@ -723,7 +724,7 @@ export function useStripeTerminal(props?: Props) {
     },
     [_isInitialized, setLoading]
   );
-  
+
   const _setSimulatedOfflineMode = useCallback(
     async (simulatedOffline: boolean) => {
       if (!_isInitialized()) {
@@ -1007,6 +1008,23 @@ export function useStripeTerminal(props?: Props) {
     [_isInitialized, setLoading]
   );
 
+  const _print = useCallback(
+    async (contentUri: string) => {
+      if (!_isInitialized()) {
+        console.error(NOT_INITIALIZED_ERROR_MESSAGE);
+        throw Error(NOT_INITIALIZED_ERROR_MESSAGE);
+      }
+      setLoading(true);
+
+      const response = await print(contentUri);
+
+      setLoading(false);
+
+      return response;
+    },
+    [_isInitialized, setLoading]
+  );
+
   const _cancelReaderReconnection = useCallback(async () => {
     if (!_isInitialized()) {
       console.error(NOT_INITIALIZED_ERROR_MESSAGE);
@@ -1103,6 +1121,7 @@ export function useStripeTerminal(props?: Props) {
     collectInputs: _collectInputs,
     cancelCollectInputs: _cancelCollectInputs,
     collectData: _collectData,
+    print: _print,
     cancelReaderReconnection: _cancelReaderReconnection,
     supportsReadersOfType: _supportsReadersOfType,
     setTapToPayUxConfiguration: _setTapToPayUxConfiguration,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -642,3 +642,5 @@ export enum DarkMode {
   LIGHT = 'light',
   SYSTEM = 'system',
 }
+
+export type PrintContent = string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -643,4 +643,10 @@ export enum DarkMode {
   SYSTEM = 'system',
 }
 
+/**
+ * Content for a print operation.
+ *
+ * Supported content:
+ * - Image (JPEG/PNG) encoded as a base64 string or 'data:' URI scheme.
+ */
 export type PrintContent = string;


### PR DESCRIPTION
## Summary

<!-- Simple summary of what was changed. -->

- Add new `print` method to SDK
   - Takes a string ("data:image/" URI or raw base64-encoded string of PNG/JPEG data) as input
   - Conversion to native image types is handled by the native modules. Implemented in #989

## Motivation

<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

Implementing printing support


## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [X] I tested this manually
    - Tested with dev-app changes in #992
- [X] I added automated tests
    - Updated tests
   
## Documentation

Select one:

- [x] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
