### PR TITLE
Add the CancelCollectData function to the SDK interface

### DIFF
--- a/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
@@ -985,6 +985,14 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
 
     @ReactMethod
     @Suppress("unused")
+    fun cancelCollectData(promise: Promise) {
+        cancelOperation(promise, collectDataCancelable, "Collect Data") {
+            collectDataCancelable = null
+        }
+    }
+
+    @ReactMethod
+    @Suppress("unused")
     fun clearCachedCredentials(promise: Promise) {
         terminal.clearCachedCredentials()
         paymentIntents.clear()

--- a/dev-app/src/screens/CollectDataScreen.tsx
+++ b/dev-app/src/screens/CollectDataScreen.tsx
@@ -15,15 +15,20 @@ import type { NavigationProp } from '@react-navigation/native';
 import type { RouteParamList } from '../App';
 
 export default function CollectDataScreen() {
-  const { addLogs, clearLogs } = useContext(LogContext);
+  const { addLogs, clearLogs, setCancel } = useContext(LogContext);
   const navigation = useNavigation<NavigationProp<RouteParamList>>();
   const [enableCustomerCancellation, setEnableCustomerCancellation] =
     useState(false);
 
-  const { collectData } = useStripeTerminal();
+  const { collectData, cancelCollectData } = useStripeTerminal();
 
   const _collectMagstripeData = async () => {
     clearLogs();
+    setCancel({
+      label: 'Cancel CollectData',
+      isDisabled: false,
+      action: cancelCollectData,
+    });
     navigation.navigate('LogListScreen', {});
 
     addLogs({
@@ -32,6 +37,7 @@ export default function CollectDataScreen() {
         {
           name: 'Collect Data',
           description: 'terminal.collectData',
+          onBack: cancelCollectData,
         },
       ],
     });
@@ -78,6 +84,11 @@ export default function CollectDataScreen() {
 
   const _collectNfcUid = async () => {
     clearLogs();
+    setCancel({
+      label: 'Cancel CollectData',
+      isDisabled: false,
+      action: cancelCollectData,
+    });
     navigation.navigate('LogListScreen', {});
 
     addLogs({
@@ -86,6 +97,7 @@ export default function CollectDataScreen() {
         {
           name: 'Collect Data',
           description: 'terminal.collectData',
+          onBack: cancelCollectData,
         },
       ],
     });

--- a/ios/StripeTerminalReactNative.m
+++ b/ios/StripeTerminalReactNative.m
@@ -182,6 +182,11 @@ RCT_EXTERN_METHOD(
                   )
 
 RCT_EXTERN_METHOD(
+                  cancelCollectData:(RCTPromiseResolveBlock)resolve
+                  rejecter: (RCTPromiseRejectBlock)reject
+                  )
+
+RCT_EXTERN_METHOD(
                   cancelCollectSetupIntent:(RCTPromiseResolveBlock)resolve
                   rejecter: (RCTPromiseRejectBlock)reject
                   )

--- a/src/StripeTerminalSdk.tsx
+++ b/src/StripeTerminalSdk.tsx
@@ -145,8 +145,10 @@ export interface StripeTerminalSdkType {
   }>;
   setSimulatedOfflineMode(simulatedOffline: boolean): Promise<{
     error?: StripeError;
-    }>;
-  setSimulatedCollectInputsResult(simulatedCollectInputsBehavior: string): Promise<{
+  }>;
+  setSimulatedCollectInputsResult(
+    simulatedCollectInputsBehavior: string
+  ): Promise<{
     error?: StripeError;
   }>;
   getOfflineStatus(): Promise<OfflineStatus>;
@@ -164,6 +166,9 @@ export interface StripeTerminalSdkType {
     error?: StripeError;
   }>;
   collectData(params: CollectDataParams): Promise<CollectDataResultType>;
+  cancelCollectData(): Promise<{
+    error?: StripeError;
+  }>;
   cancelReaderReconnection(): Promise<{
     error?: StripeError;
   }>;

--- a/src/__tests__/__snapshots__/functions.test.ts.snap
+++ b/src/__tests__/__snapshots__/functions.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`functions.test.ts Functions snapshot ensure there are no unexpected changes to the functions exports 1`] = `
 {
+  "cancelCollectData": [Function],
   "cancelCollectInputs": [Function],
   "cancelCollectPaymentMethod": [Function],
   "cancelCollectRefundPaymentMethod": [Function],

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -880,6 +880,21 @@ export async function collectData(
   }, 'collectData')();
 }
 
+export async function cancelCollectData(): Promise<{
+  error?: StripeError;
+}> {
+  return Logger.traceSdkMethod(async () => {
+    try {
+      await StripeTerminalSdk.cancelCollectData();
+      return {};
+    } catch (error) {
+      return {
+        error: error as any,
+      };
+    }
+  }, 'cancelCollectData')();
+}
+
 export async function cancelReaderReconnection(): Promise<{
   error?: StripeError;
 }> {

--- a/src/hooks/__tests__/__snapshots__/useStripeTerminal.test.tsx.snap
+++ b/src/hooks/__tests__/__snapshots__/useStripeTerminal.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`useStripeTerminal.test.tsx Public API snapshot ensure there are no unexpected changes to the hook exports 1`] = `
 {
   "current": {
+    "cancelCollectData": [Function],
     "cancelCollectInputs": [Function],
     "cancelCollectPaymentMethod": [Function],
     "cancelCollectRefundPaymentMethod": [Function],

--- a/src/hooks/useStripeTerminal.tsx
+++ b/src/hooks/useStripeTerminal.tsx
@@ -69,6 +69,7 @@ import {
   collectInputs,
   cancelCollectInputs,
   collectData,
+  cancelCollectData,
   cancelReaderReconnection,
   supportsReadersOfType,
   getPaymentStatus,
@@ -1007,6 +1008,20 @@ export function useStripeTerminal(props?: Props) {
     [_isInitialized, setLoading]
   );
 
+  const _cancelCollectData = useCallback(async () => {
+    if (!_isInitialized()) {
+      console.error(NOT_INITIALIZED_ERROR_MESSAGE);
+      throw Error(NOT_INITIALIZED_ERROR_MESSAGE);
+    }
+    setLoading(true);
+
+    const response = await cancelCollectData();
+
+    setLoading(false);
+
+    return response;
+  }, [_isInitialized, setLoading]);
+
   const _cancelReaderReconnection = useCallback(async () => {
     if (!_isInitialized()) {
       console.error(NOT_INITIALIZED_ERROR_MESSAGE);
@@ -1103,6 +1118,7 @@ export function useStripeTerminal(props?: Props) {
     collectInputs: _collectInputs,
     cancelCollectInputs: _cancelCollectInputs,
     collectData: _collectData,
+    cancelCollectData: _cancelCollectData,
     cancelReaderReconnection: _cancelReaderReconnection,
     supportsReadersOfType: _supportsReadersOfType,
     setTapToPayUxConfiguration: _setTapToPayUxConfiguration,


### PR DESCRIPTION
## Summary

<!-- Simple summary of what was changed. -->
Add the `cancelCollectData` function to the SDK interface. If a user starts a collectData operation and wants to cancel it, they can use this new function.

## Motivation

<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->
We found an issue during the regression: we can't cancel the collectData operation. Hence, this PR is for adding the `cancelCollectData` function.
We also update the dev-app to show the `cancelCollectData` function.

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

<img width="457" height="935" alt="image" src="https://github.com/user-attachments/assets/84929cfa-a984-4df9-afa6-c9a38b32fd1a" />

- [X] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
