### PR TITLE
Fix named argument issue for Promise usage in Android

### DIFF
--- a/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
@@ -239,8 +239,8 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
         val validBehavior = setOf("all", "none", "timeout")
         if (simulatedCollectInputsBehavior !in validBehavior) {
             promise.reject(
-                code = "Failed",
-                message = "The simulatedCollectInputsBehavior must be \"all\", \"none\", or \"timeout\"."
+                "Failed",
+                "The simulatedCollectInputsBehavior must be \"all\", \"none\", or \"timeout\"."
             )
         }
 


### PR DESCRIPTION
## Summary

Fix named argument issue for Promise usage in Android

## Motivation

https://jira.corp.stripe.com/browse/TERMINAL-48539

Promise change from Java to Kotlin in 2024/08, and named argument is not support in Java. So we need to remove that in SDK to avoid build fail for user using old react native SDK like 0.74 or any old version before the migration.
Ref: https://github.com/facebook/react-native/pull/44587

## Testing

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
