### PR TITLE
Bump iOS/Android SDKs to 4.6.0

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -14,7 +14,7 @@ StripeTerminalReactNative_compileSdkVersion=35
 StripeTerminalReactNative_buildToolsVersion=35.0.0
 StripeTerminalReactNative_kotlinVersion=2.0.21
 StripeTerminalReactNative_targetSdkVersion=35
-StripeTerminalReactNative_terminalSdkVersion=4.5.1
+StripeTerminalReactNative_terminalSdkVersion=4.6.0
 StripeTerminalReactNative_taptopay.enabled=true
 android.useAndroidX=true
 

--- a/dev-app/ios/Podfile.lock
+++ b/dev-app/ios/Podfile.lock
@@ -1676,11 +1676,11 @@ PODS:
   - SocketRocket (0.7.1)
   - stripe-terminal-react-native (0.0.1-beta.26):
     - React-Core
-    - StripeTerminal (~> 4.5.0)
+    - StripeTerminal (~> 4.6.0)
   - stripe-terminal-react-native/Tests (0.0.1-beta.26):
     - React-Core
-    - StripeTerminal (~> 4.5.0)
-  - StripeTerminal (4.5.0)
+    - StripeTerminal (~> 4.6.0)
+  - StripeTerminal (4.6.0)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -1984,8 +1984,8 @@ SPEC CHECKSUMS:
   RNGestureHandler: 66e593addd8952725107cfaa4f5e3378e946b541
   RNScreens: 0f01bbed9bd8045a8d58e4b46993c28c7f498f3c
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  stripe-terminal-react-native: cecfeb195620eccb890c0997038ab42e0fea6fa9
-  StripeTerminal: 29fc3756591e0ae42f7cd43619b4293cdcfa9374
+  stripe-terminal-react-native: ad61c5eeccc0d936ff853ac1b58de1d248285421
+  StripeTerminal: 579a973109a553543d25e53a6f596230a72ce8a9
   Yoga: 31a098f74c16780569aebd614a0f37a907de0189
 
 PODFILE CHECKSUM: 7bb7fbbd263bda35e47b3f64ad5fbd6c589aa428

--- a/ios/StripeTerminalReactNative.swift
+++ b/ios/StripeTerminalReactNative.swift
@@ -723,7 +723,13 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, MobileReade
       
         let confirmConfigBuilder = ConfirmConfigurationBuilder()
         if let amountSurchargeValue = amountSurcharge {
-          confirmConfigBuilder.setAmountSurcharge(UInt(truncating: amountSurchargeValue))
+          do {
+            let surchargeConfig = try SurchargeConfigurationBuilder().setAmount(UInt(truncating: amountSurchargeValue)).build()
+            confirmConfigBuilder.setSurchargeConfiguration(surchargeConfig)
+          } catch {
+            resolve(Errors.createError(nsError: error as NSError))
+            return
+          }
         }
 
         if let returnUrlValue = returnUrl {

--- a/stripe-terminal-react-native.podspec
+++ b/stripe-terminal-react-native.podspec
@@ -21,5 +21,5 @@ Pod::Spec.new do |s|
   end
 
   s.dependency 'React-Core'
-  s.dependency 'StripeTerminal', '~> 4.5.0'
+  s.dependency 'StripeTerminal', '~> 4.6.0'
 end


### PR DESCRIPTION
## Summary

<!-- Simple summary of what was changed. -->

- Bump Android/iOS SDKs to version 4.6.0
    - **Changelogs**:
        - [Android](https://github.com/stripe/stripe-terminal-android/blob/master/CHANGELOG.md#460---2025-08-01)
        - [iOS](https://github.com/stripe/stripe-terminal-ios/blob/master/CHANGELOG.md#460-2025-08-04)

## Motivation

<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

Bringing in new SDK changes for printing support

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [X] I tested this manually
- [ ] I added automated tests

Ensure CI passes

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [X] This PR does not result in any developer-facing changes.
