### PR TITLE
Update Surcharge operation to support new configuration

### DIFF
--- a/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/Mappers.kt
@@ -1074,3 +1074,29 @@ fun hexToArgb(color: String): Int {
         throw IllegalArgumentException("Invalid ARGB hex format", e)
     }
 }
+
+
+@OptIn(Surcharging::class)
+fun mapToSurchargeConfiguration(surchargeMap: ReadableMap): SurchargeConfiguration? {
+    if (surchargeMap.hasKey("amount").not()) return null
+
+    val consent = surchargeMap.getMap("consent")?.let { consentMap ->
+        val surchargeConsentCollection =
+            consentMap.getString("collection")?.let { SurchargeConsentCollection.fromCollection(it) }
+        val collection = when (surchargeConsentCollection) {
+            SurchargeConsentCollection.DISABLED -> NativeSurchargeConsentCollection.DISABLED
+            SurchargeConsentCollection.ENABLED -> NativeSurchargeConsentCollection.ENABLED
+            null -> NativeSurchargeConsentCollection.DISABLED
+        }
+        val consentBuilder = SurchargeConsent.Builder(collection)
+
+        val notice = consentMap.getString("notice") ?: ""
+        consentBuilder.setNotice(notice)
+            .build()
+    } ?: SurchargeConsent.Builder().build()
+
+    val amount = surchargeMap.getLongSafely("amount") ?: 0L
+    return SurchargeConfiguration.Builder(amount)
+        .setConsent(consent)
+        .build()
+}

--- a/android/src/main/java/com/stripeterminalreactnative/ReactNativeConstants.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/ReactNativeConstants.kt
@@ -55,3 +55,14 @@ enum class DeviceSerialName(val serialName: String) {
         fun fromSerialName(serialName: String): DeviceSerialName? = serialNames[serialName]
     }
 }
+
+enum class SurchargeConsentCollection(val collection: String) {
+    DISABLED("disabled"),
+    ENABLED("enabled");
+
+    companion object {
+        private val collections = SurchargeConsentCollection.entries.associateBy(SurchargeConsentCollection::collection)
+
+        fun fromCollection(collection: String): SurchargeConsentCollection? = collections[collection]
+    }
+}

--- a/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
@@ -708,11 +708,10 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
 
         val configBuilder = ConfirmConfiguration.Builder()
 
-        if (params.hasKey("amountSurcharge")) {
-            val amountSurcharge = params.getLongSafely("amountSurcharge") ?: 0L
-            val surchargeConfiguration = SurchargeConfiguration.Builder(amountSurcharge).build()
-            configBuilder.setSurcharge(surchargeConfiguration)
+        val surchargeConfiguration = params.getMap("surcharge")?.let {
+            mapToSurchargeConfiguration(it)
         }
+        configBuilder.setSurcharge(surchargeConfiguration)
 
         if (params.hasKey("returnUrl")) {
             val returnUrl = params.getString("returnUrl")

--- a/dev-app/src/screens/CollectCardPaymentScreen.tsx
+++ b/dev-app/src/screens/CollectCardPaymentScreen.tsx
@@ -999,7 +999,7 @@ export default function CollectCardPaymentScreen() {
             placeholder="Surcharge Amount"
           />
           <ListItem
-            title="Enable Surcharge Consent Configuration   "
+            title="Enable Surcharge Consent Configuration"
             rightElement={
               <Switch
                 testID="toggle-surcharge-consent"
@@ -1017,6 +1017,25 @@ export default function CollectCardPaymentScreen() {
           />
           {surcharge.consent !== null ? (
             <View>
+              <ListItem
+                title="Enable Collecting User Consent"
+                rightElement={
+                  <Switch
+                    testID="enable-collecting-user-consent"
+                    value={surcharge.consent.collection === 'enabled'}
+                    onValueChange={(value) =>
+                      setSurcharge((prev) => ({
+                        ...prev,
+                        consent: {
+                          ...prev.consent!,
+                          collection: value ? 'enabled' : 'disabled',
+                        },
+                      }))
+                    }
+                  />
+                }
+              />
+
               <TextInput
                 testID="Surcharge Consent Notice"
                 style={styles.input}
@@ -1031,25 +1050,6 @@ export default function CollectCardPaymentScreen() {
                   }))
                 }
                 placeholder="Surcharge Consent Notice"
-              />
-
-              <ListItem
-                title="Enable Surcharge Consent Collection"
-                rightElement={
-                  <Switch
-                    testID="enable-surcharge-consent-collection"
-                    value={surcharge.consent.collection === 'enabled'}
-                    onValueChange={(value) =>
-                      setSurcharge((prev) => ({
-                        ...prev,
-                        consent: {
-                          ...prev.consent!,
-                          collection: value ? 'enabled' : 'disabled',
-                        },
-                      }))
-                    }
-                  />
-                }
               />
             </View>
           ) : (

--- a/dev-app/src/screens/CollectCardPaymentScreen.tsx
+++ b/dev-app/src/screens/CollectCardPaymentScreen.tsx
@@ -1,4 +1,9 @@
-import { useNavigation, useRoute, type RouteProp, type NavigationProp } from '@react-navigation/core';
+import {
+  useNavigation,
+  useRoute,
+  type RouteProp,
+  type NavigationProp,
+} from '@react-navigation/core';
 import React, { useState, useContext, useRef } from 'react';
 import { Picker } from '@react-native-picker/picker';
 import {
@@ -55,7 +60,7 @@ const CAPTURE_METHODS = [
 ];
 
 const CARD_PRESENT_CAPTURE_METHODS = [
-  { value: undefined, label: 'default'},
+  { value: undefined, label: 'default' },
   { value: 'manual', label: 'manual' },
   { value: 'manual_preferred', label: 'manual_preferred' },
 ];

--- a/ios/Mappers.swift
+++ b/ios/Mappers.swift
@@ -1079,7 +1079,7 @@ class Mappers {
 
     class func mapToSurchargeConfiguration(from dict: [String: Any]?) throws -> SurchargeConfiguration? {
         guard let dict = dict else { return nil }
-        guard let amount = dict["amount"] as? Int else {
+        guard let amount = dict["amount"] as? UInt else {
             return nil
         }
         
@@ -1090,7 +1090,7 @@ class Mappers {
         if let consentDict = dict["consent"] as? [String: Any] {
             if let collectionString = consentDict["collection"] as? String {
                 let collection: SurchargeConsentCollection
-                switch collectionString {
+              switch collectionString.lowercased() {
                     case "enabled":
                         collection = .enabled
                     case "disabled":

--- a/ios/Mappers.swift
+++ b/ios/Mappers.swift
@@ -1090,7 +1090,7 @@ class Mappers {
         if let consentDict = dict["consent"] as? [String: Any] {
             if let collectionString = consentDict["collection"] as? String {
                 let collection: SurchargeConsentCollection
-              switch collectionString.lowercased() {
+                switch collectionString.lowercased() {
                     case "enabled":
                         collection = .enabled
                     case "disabled":

--- a/ios/Mappers.swift
+++ b/ios/Mappers.swift
@@ -1084,7 +1084,7 @@ class Mappers {
         }
         
         let surchargeConfigBuilder = SurchargeConfigurationBuilder()
-        surchargeConfigBuilder.setAmount(UInt(amount))
+        surchargeConfigBuilder.setAmount(amount)
         
         let consentBuilder = SurchargeConsentBuilder()
         if let consentDict = dict["consent"] as? [String: Any] {

--- a/ios/Mappers.swift
+++ b/ios/Mappers.swift
@@ -1075,6 +1075,42 @@ class Mappers {
         default: return .unknown
         }
     }
+  
+
+    class func mapToSurchargeConfiguration(from dict: [String: Any]?) throws -> SurchargeConfiguration? {
+        guard let dict = dict else { return nil }
+        guard let amount = dict["amount"] as? Int else {
+            return nil
+        }
+        
+        let surchargeConfigBuilder = SurchargeConfigurationBuilder()
+        surchargeConfigBuilder.setAmount(UInt(amount))
+        
+        let consentBuilder = SurchargeConsentBuilder()
+        if let consentDict = dict["consent"] as? [String: Any] {
+            if let collectionString = consentDict["collection"] as? String {
+                let collection: SurchargeConsentCollection
+                switch collectionString {
+                    case "enabled":
+                        collection = .enabled
+                    case "disabled":
+                        collection = .disabled
+                    default:
+                        collection = .disabled
+                }
+                consentBuilder.setCollection(collection)
+            } else {
+                consentBuilder.setCollection(.disabled)
+            }
+            
+            if let notice = consentDict["notice"] as? String {
+                consentBuilder.setNotice(notice)
+            }
+        }
+        surchargeConfigBuilder.setSurchargeConsent(try consentBuilder.build())
+        
+      return try surchargeConfigBuilder.build()
+    }
 }
 
 extension UInt {

--- a/ios/StripeTerminalReactNative.swift
+++ b/ios/StripeTerminalReactNative.swift
@@ -719,20 +719,19 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, MobileReade
             return
         }
         
-        let amountSurcharge = params["amountSurcharge"] as? NSNumber
-        let returnUrl = params["returnUrl"] as? String
-      
         let confirmConfigBuilder = ConfirmConfigurationBuilder()
-        if let amountSurchargeValue = amountSurcharge {
-          do {
-            let surchargeConfig = try SurchargeConfigurationBuilder().setAmount(UInt(truncating: amountSurchargeValue)).build()
-            confirmConfigBuilder.setSurchargeConfiguration(surchargeConfig)
-          } catch {
-            resolve(Errors.createError(nsError: error as NSError))
-            return
-          }
+        if let surchargeDict = params["surcharge"] as? [String: Any] {
+            do {
+              if let surchargeConfiguration = try Mappers.mapToSurchargeConfiguration(from: surchargeDict) {
+                confirmConfigBuilder.setSurchargeConfiguration(surchargeConfiguration)
+              }
+            } catch let error as NSError {
+              resolve(Errors.createError(nsError: error))
+              return
+            }
         }
 
+        let returnUrl = params["returnUrl"] as? String
         if let returnUrlValue = returnUrl {
             confirmConfigBuilder.setReturnUrl(returnUrlValue)
         }

--- a/ios/StripeTerminalReactNative.swift
+++ b/ios/StripeTerminalReactNative.swift
@@ -720,24 +720,19 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, MobileReade
         }
         
         let confirmConfigBuilder = ConfirmConfigurationBuilder()
-        if let surchargeDict = params["surcharge"] as? [String: Any] {
-            do {
-              if let surchargeConfiguration = try Mappers.mapToSurchargeConfiguration(from: surchargeDict) {
-                confirmConfigBuilder.setSurchargeConfiguration(surchargeConfiguration)
-              }
-            } catch let error as NSError {
-              resolve(Errors.createError(nsError: error))
-              return
-            }
-        }
-
-        let returnUrl = params["returnUrl"] as? String
-        if let returnUrlValue = returnUrl {
-            confirmConfigBuilder.setReturnUrl(returnUrlValue)
-        }
-
         let confirmConfig: ConfirmConfiguration
         do {
+            if let surchargeDict = params["surcharge"] as? [String: Any] {
+                if let surchargeConfiguration = try Mappers.mapToSurchargeConfiguration(from: surchargeDict) {
+                  confirmConfigBuilder.setSurchargeConfiguration(surchargeConfiguration)
+                }
+            }
+
+            let returnUrl = params["returnUrl"] as? String
+            if let returnUrlValue = returnUrl {
+                confirmConfigBuilder.setReturnUrl(returnUrlValue)
+            }
+
             confirmConfig = try confirmConfigBuilder.build()
         } catch {
             resolve(Errors.createError(nsError: error as NSError))

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -209,9 +209,21 @@ export type CollectPaymentMethodParams = {
 
 export type ConfirmPaymentMethodParams = {
   paymentIntent: PaymentIntent.Type;
-  amountSurcharge?: number;
+  surcharge?: Surcharge;
   returnUrl?: string;
 };
+
+export type Surcharge = {
+  amount: number;
+  consent?: SurchargeConsent | null;
+};
+
+export type SurchargeConsent = {
+  notice: string;
+  collection: SurchargeConsentCollection;
+};
+
+export type SurchargeConsentCollection = 'disabled' | 'enabled';
 
 export type CancelPaymentMethodParams = {
   paymentIntent: PaymentIntent.Type;


### PR DESCRIPTION
## Summary

To support the new Surcharge Configuration exposed by Android SDK 4.5.0 and iOS SDK 4.6.0. We need to update the React Native SDK.
Android SDK release note: https://github.com/stripe/stripe-terminal-android/blob/master/CHANGELOG.md#450---2025-06-10 
iOS SDK release note: https://github.com/stripe/stripe-terminal-ios/releases/tag/4.6.0 

We add a new consent field to get users' consent related to the surcharge fee.

## Motivation

For the new Surcharge Configuration

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->
<img width="465" height="901" alt="dev-app surcharge" src="https://github.com/user-attachments/assets/c7df864b-0cce-471f-9f6b-c98f5ec917cb" />
<img width="461" height="762" alt="dev-app surcharge log" src="https://github.com/user-attachments/assets/4b3e22f8-d3a8-4589-86ce-a50e0efb61f8" />

**There is one last step left, verify consent.**

- [X] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

**Need to update the document**

- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.