### PR TITLE
add additional type for `wisePosEDevkit`

### DIFF
--- a/src/types/Reader.ts
+++ b/src/types/Reader.ts
@@ -102,7 +102,6 @@ export namespace Reader {
     | 'wisePosE'
     | 'wisePosEDevkit'
     | 'wisePad3s'
-    | 'wisePadEDevkit'
     | 'stripeS700Devkit'
     | 'stripeS700'
     | 'stripeS710Devkit'


### PR DESCRIPTION
## Summary

<!-- Simple summary of what was changed. -->

Appears a couple references to `wisePosEDevkit` was added in https://github.com/stripe/stripe-terminal-react-native/commit/9d7dee7a6821288da2de902640930f0e9c27a02c , but there was a typo in `DeviceType` with `wisePadEDevkit` (pad instead of pos).

replaced `wisePadEDevkit` with `wisePosEDevkit`

## Motivation

<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

https://github.com/stripe/stripe-terminal-react-native/issues/1015

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [ ] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [ ] This PR does not result in any developer-facing changes.
