### PR TITLE
Add USB driver to Fastfile and add NSPhotoLibraryUsageDescription

### DIFF
--- a/dev-app/ios/StripeTerminalReactNativeDevApp/Info.plist
+++ b/dev-app/ios/StripeTerminalReactNativeDevApp/Info.plist
@@ -62,5 +62,8 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+  <key>NSPhotoLibraryUsageDescription</key>
+  <string>This app can use images of receipts from your photo library to print
+</string>
 </dict>
 </plist>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -36,7 +36,7 @@ end
 
 lane :publish_ios_to_testflight do |options|
 
-  match(app_identifier: "com.stripe.terminal.reactnative.dev.app")
+  match(app_identifier: ["com.stripe.terminal.reactnative.dev.app", "com.stripe.terminal.reactnative.dev.app.usb-driver"])
 
   target_build_number = latest_testflight_build_number(
     app_identifier: "com.stripe.terminal.reactnative.dev.app"


### PR DESCRIPTION
## Summary
Couple small dev-app updates needed to get deployment working again.

1. needed to add the USB driver bundle id to the match array
2. needed to add NSPhotoLibraryUsageDescription to the dev-app Info.plist as it supports getting receipts to print

<!-- Simple summary of what was changed. -->

## Motivation
fix dev-app deploy process
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

## Testing
did a deploy
<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
