### PR TITLE
Add JPY currency support and zero-decimal currency handling

### DIFF
--- a/dev-app/src/screens/CollectCardPaymentScreen.tsx
+++ b/dev-app/src/screens/CollectCardPaymentScreen.tsx
@@ -35,6 +35,7 @@ import {
   DEFAULT_ENABLED_PAYMENT_METHOD_TYPES,
   PAYMENT_METHOD_TYPES,
 } from '../util/paymentMethodTypes';
+import { formatAmountForDisplay } from '../util/currencyUtils';
 
 const CURRENCIES = [
   { value: 'usd', label: 'USD' },
@@ -46,6 +47,7 @@ const CURRENCIES = [
   { value: 'eur', label: 'EUR' },
   { value: 'gbp', label: 'GBP' },
   { value: 'hkd', label: 'HKD' },
+  { value: 'jpy', label: 'JPY' },
   { value: 'myr', label: 'MYR' },
   { value: 'nok', label: 'NOK' },
   { value: 'nzd', label: 'NZD' },
@@ -1246,8 +1248,8 @@ export default function CollectCardPaymentScreen() {
         <List
           bolded={false}
           topSpacing={false}
-          title={`${(Number(inputValues.amount) / 100).toFixed(2)} ${
-            inputValues.currency
+          title={`${formatAmountForDisplay(inputValues.amount, inputValues.currency)} ${
+            inputValues.currency.toUpperCase()
           }`}
         >
           <ListItem

--- a/dev-app/src/screens/RefundPaymentScreen.tsx
+++ b/dev-app/src/screens/RefundPaymentScreen.tsx
@@ -22,6 +22,7 @@ import ListItem from '../components/ListItem';
 import { LogContext } from '../components/LogContext';
 import { AppContext } from '../AppContext';
 import type { RouteParamList } from '../App';
+import { formatAmountForDisplay } from '../util/currencyUtils';
 import { Picker } from '@react-native-picker/picker';
 import type { NavigationProp } from '@react-navigation/native';
 
@@ -385,8 +386,8 @@ export default function RefundPaymentScreen() {
       <List
         bolded={false}
         topSpacing={false}
-        title={`${(Number(inputValues.amount) / 100).toFixed(2)} ${
-          inputValues.currency
+        title={`${formatAmountForDisplay(inputValues.amount, inputValues.currency)} ${
+          inputValues.currency.toUpperCase()
         }`}
       >
         <ListItem

--- a/dev-app/src/util/currencyUtils.ts
+++ b/dev-app/src/util/currencyUtils.ts
@@ -1,0 +1,13 @@
+// Zero-decimal currencies (amounts are specified in the currency unit, not its subdivision)
+const ZERO_DECIMAL_CURRENCIES = [
+  'jpy', 'krw', 'bif', 'clp', 'djf', 'gnf', 'isk', 'kmf',
+  'pyg', 'rwf', 'ugx', 'vnd', 'vuv', 'xaf', 'xof', 'xpf',
+];
+
+export const formatAmountForDisplay = (amount: string, currency: string): string => {
+  const numAmount = Number(amount);
+  if (ZERO_DECIMAL_CURRENCIES.includes(currency.toLowerCase())) {
+    return numAmount.toString();
+  }
+  return (numAmount / 100).toFixed(2);
+};

--- a/example-app/src/screens/CollectCardPaymentScreen.tsx
+++ b/example-app/src/screens/CollectCardPaymentScreen.tsx
@@ -19,6 +19,7 @@ import {
   DEFAULT_ENABLED_PAYMENT_METHOD_TYPES,
   PAYMENT_METHOD_TYPES,
 } from '../util/paymentMethodTypes';
+import { formatAmountForDisplay } from '../util/currencyUtils';
 
 const CURRENCIES = [
   { value: 'usd', label: 'USD' },
@@ -30,6 +31,7 @@ const CURRENCIES = [
   { value: 'eur', label: 'EUR' },
   { value: 'gbp', label: 'GBP' },
   { value: 'hkd', label: 'HKD' },
+  { value: 'jpy', label: 'JPY' },
   { value: 'myr', label: 'MYR' },
   { value: 'nok', label: 'NOK' },
   { value: 'nzd', label: 'NZD' },
@@ -770,8 +772,8 @@ export default function CollectCardPaymentScreen() {
       <List
         bolded={false}
         topSpacing={false}
-        title={`${(Number(inputValues.amount) / 100).toFixed(2)} ${
-          inputValues.currency
+        title={`${formatAmountForDisplay(inputValues.amount, inputValues.currency)} ${
+          inputValues.currency.toUpperCase()
         }`}
       >
         <ListItem

--- a/example-app/src/screens/RefundPaymentScreen.tsx
+++ b/example-app/src/screens/RefundPaymentScreen.tsx
@@ -9,6 +9,7 @@ import ListItem from '../components/ListItem';
 import { LogContext } from '../components/LogContext';
 import { AppContext } from '../AppContext';
 import type { RouteParamList } from '../App';
+import { formatAmountForDisplay } from '../util/currencyUtils';
 
 export default function RefundPaymentScreen() {
   const { lastSuccessfulChargeId } = useContext(AppContext);
@@ -290,8 +291,8 @@ export default function RefundPaymentScreen() {
       <List
         bolded={false}
         topSpacing={false}
-        title={`${(Number(inputValues.amount) / 100).toFixed(2)} ${
-          inputValues.currency
+        title={`${formatAmountForDisplay(inputValues.amount, inputValues.currency)} ${
+          inputValues.currency.toUpperCase()
         }`}
       >
         <ListItem

--- a/example-app/src/util/currencyUtils.ts
+++ b/example-app/src/util/currencyUtils.ts
@@ -1,0 +1,13 @@
+// Zero-decimal currencies (amounts are specified in the currency unit, not its subdivision)
+const ZERO_DECIMAL_CURRENCIES = [
+  'jpy', 'krw', 'bif', 'clp', 'djf', 'gnf', 'isk', 'kmf',
+  'pyg', 'rwf', 'ugx', 'vnd', 'vuv', 'xaf', 'xof', 'xpf',
+];
+
+export const formatAmountForDisplay = (amount: string, currency: string): string => {
+  const numAmount = Number(amount);
+  if (ZERO_DECIMAL_CURRENCIES.includes(currency.toLowerCase())) {
+    return numAmount.toString();
+  }
+  return (numAmount / 100).toFixed(2);
+};


### PR DESCRIPTION
cc @uintaam

## Summary

Added JPY currency support and implemented zero-decimal currency handling in both example-app and dev-app. Zero-decimal currencies (JPY, KRW, etc.) now display amounts correctly without dividing by 100, while regular currencies continue to work as before.

## Motivation

JPY was missing from the supported currencies list in the demo applications. Additionally, the existing amount formatting logic incorrectly divided all amounts by 100, which is incorrect for zero-decimal currencies like JPY where amounts are already in the base currency unit (¥100 should display as "100", not "1.00").

This change ensures proper currency support and display formatting for international users, particularly those using Japanese Yen and other zero-decimal currencies.