### PR TITLE
Change token callback usage and functionality

### DIFF
--- a/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/StripeTerminalReactNativeModule.kt
@@ -260,7 +260,6 @@ class StripeTerminalReactNativeModule(reactContext: ReactApplicationContext) :
         tokenProvider.setConnectionToken(
             token = params.getString("token"),
             error = params.getString("error"),
-            callbackId = params.getString("callbackId")
         )
         promise.resolve(null)
     }

--- a/android/src/main/java/com/stripeterminalreactnative/TokenProvider.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/TokenProvider.kt
@@ -7,11 +7,10 @@ import com.stripe.stripeterminal.external.models.ConnectionTokenException
 import com.stripeterminalreactnative.ReactExtensions.sendEvent
 import com.stripeterminalreactnative.ReactNativeConstants.FETCH_TOKEN_PROVIDER
 import java.util.Queue
-import java.util.UUID
 import java.util.concurrent.ConcurrentLinkedQueue
 
 class TokenProvider(private val context: ReactApplicationContext) : ConnectionTokenProvider {
-    var queue: Queue<ConnectionTokenCallback> = ConcurrentLinkedQueue()
+    val queue: Queue<ConnectionTokenCallback> = ConcurrentLinkedQueue()
 
     fun setConnectionToken(token: String?, error: String?, callbackId: String?) {
         while (queue.isNotEmpty()) {
@@ -22,7 +21,7 @@ class TokenProvider(private val context: ReactApplicationContext) : ConnectionTo
                 } else {
                     connectionTokenCallback.onFailure(
                         ConnectionTokenException(
-                            error ?: "",
+                            error ?: "Token is invalid",
                             null
                         )
                     )
@@ -39,10 +38,9 @@ class TokenProvider(private val context: ReactApplicationContext) : ConnectionTo
     }
 
     override fun fetchConnectionToken(callback: ConnectionTokenCallback) {
-        val uuid = UUID.randomUUID().toString()
         queue.offer(callback)
         context.sendEvent(FETCH_TOKEN_PROVIDER.listenerName) {
-            putString("callbackId", uuid)
+            putString("callbackId", "")
         }
     }
 }

--- a/android/src/main/java/com/stripeterminalreactnative/TokenProvider.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/TokenProvider.kt
@@ -12,7 +12,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
 class TokenProvider(private val context: ReactApplicationContext) : ConnectionTokenProvider {
     val queue: Queue<ConnectionTokenCallback> = ConcurrentLinkedQueue()
 
-    fun setConnectionToken(token: String?, error: String?, callbackId: String?) {
+    fun setConnectionToken(token: String?, error: String?) {
         while (queue.isNotEmpty()) {
             val connectionTokenCallback = queue.poll() ?: break
             try {
@@ -39,8 +39,6 @@ class TokenProvider(private val context: ReactApplicationContext) : ConnectionTo
 
     override fun fetchConnectionToken(callback: ConnectionTokenCallback) {
         queue.offer(callback)
-        context.sendEvent(FETCH_TOKEN_PROVIDER.listenerName) {
-            putString("callbackId", "")
-        }
+        context.sendEvent(FETCH_TOKEN_PROVIDER.listenerName)
     }
 }

--- a/android/src/main/java/com/stripeterminalreactnative/TokenProvider.kt
+++ b/android/src/main/java/com/stripeterminalreactnative/TokenProvider.kt
@@ -6,38 +6,41 @@ import com.stripe.stripeterminal.external.callable.ConnectionTokenProvider
 import com.stripe.stripeterminal.external.models.ConnectionTokenException
 import com.stripeterminalreactnative.ReactExtensions.sendEvent
 import com.stripeterminalreactnative.ReactNativeConstants.FETCH_TOKEN_PROVIDER
-import java.util.Hashtable
+import java.util.Queue
 import java.util.UUID
+import java.util.concurrent.ConcurrentLinkedQueue
 
 class TokenProvider(private val context: ReactApplicationContext) : ConnectionTokenProvider {
-    var callbackMap: Hashtable<String, ConnectionTokenCallback> = Hashtable()
+    var queue: Queue<ConnectionTokenCallback> = ConcurrentLinkedQueue()
 
     fun setConnectionToken(token: String?, error: String?, callbackId: String?) {
-        if (callbackId.isNullOrEmpty() || callbackMap[callbackId] == null) {
-            throw ConnectionTokenException(
-                "setConnectionToken requires the callbackId to be set to the callbackId value provided to the tokenProviderHandler."
-            )
-        }
-
-        val connectionTokenCallback = callbackMap[callbackId]
-        if (connectionTokenCallback != null) {
+        while (queue.isNotEmpty()) {
+            val connectionTokenCallback = queue.poll() ?: break
             try {
                 if (!token.isNullOrEmpty()) {
                     connectionTokenCallback.onSuccess(token)
                 } else {
-                    connectionTokenCallback.onFailure(ConnectionTokenException(error ?: "", null))
+                    connectionTokenCallback.onFailure(
+                        ConnectionTokenException(
+                            error ?: "",
+                            null
+                        )
+                    )
                 }
             } catch (e: Throwable) {
-                connectionTokenCallback.onFailure(ConnectionTokenException("Failed to fetch connection token", e))
-            } finally {
-                callbackMap.remove(callbackId)
+                connectionTokenCallback.onFailure(
+                    ConnectionTokenException(
+                        "Failed to fetch connection token",
+                        e
+                    )
+                )
             }
         }
     }
 
     override fun fetchConnectionToken(callback: ConnectionTokenCallback) {
         val uuid = UUID.randomUUID().toString()
-        callbackMap[uuid] = callback
+        queue.offer(callback)
         context.sendEvent(FETCH_TOKEN_PROVIDER.listenerName) {
             putString("callbackId", uuid)
         }

--- a/android/src/test/java/com/stripeterminalreactnative/TokenProviderTest.kt
+++ b/android/src/test/java/com/stripeterminalreactnative/TokenProviderTest.kt
@@ -43,7 +43,7 @@ class TokenProviderTest {
         }
         verify { callback wasNot Called }
 
-        tokenProvider.setConnectionToken(TOKEN, ERROR, "")
+        tokenProvider.setConnectionToken(TOKEN, ERROR)
         assertTrue { tokenProvider.queue.isEmpty() }
 
         verify(exactly = 1) { callback.onSuccess(TOKEN) }
@@ -58,7 +58,7 @@ class TokenProviderTest {
         assertTrue { tokenProvider.queue.count() == 1 }
         verify(exactly = 1) { context.sendEvent(FETCH_TOKEN_PROVIDER.listenerName, any()) }
         verify { callback wasNot Called }
-        tokenProvider.setConnectionToken(null, ERROR, "")
+        tokenProvider.setConnectionToken(null, ERROR)
 
         verify(exactly = 0) { callback.onSuccess(any()) }
         verify(exactly = 1) { callback.onFailure(any()) }
@@ -67,7 +67,7 @@ class TokenProviderTest {
 
         assertTrue { tokenProvider.queue.count() == 1 }
         verify(exactly = 2) { context.sendEvent(FETCH_TOKEN_PROVIDER.listenerName, any()) }
-        tokenProvider.setConnectionToken(null, null, "")
+        tokenProvider.setConnectionToken(null, null)
 
         verify(exactly = 0) { callback.onSuccess(any()) }
         verify(exactly = 2) { callback.onFailure(any()) }
@@ -88,7 +88,7 @@ class TokenProviderTest {
         verify(exactly = 2) { context.sendEvent(FETCH_TOKEN_PROVIDER.listenerName, any()) }
         verify { callback wasNot Called }
         verify { callback2 wasNot Called }
-        tokenProvider.setConnectionToken(null, ERROR, "")
+        tokenProvider.setConnectionToken(null, ERROR)
 
         verify(exactly = 0) { callback.onSuccess(any()) }
         verify(exactly = 0) { callback2.onSuccess(any()) }
@@ -107,7 +107,7 @@ class TokenProviderTest {
         verify(exactly = 2) { context.sendEvent(FETCH_TOKEN_PROVIDER.listenerName, any()) }
         verify { callback wasNot Called }
         verify { callback2 wasNot Called }
-        tokenProvider.setConnectionToken(TOKEN, null, "")
+        tokenProvider.setConnectionToken(TOKEN, null)
 
         verify(exactly = 1) { callback.onSuccess(any()) }
         verify(exactly = 1) { callback2.onSuccess(any()) }

--- a/ios/StripeTerminalReactNative.swift
+++ b/ios/StripeTerminalReactNative.swift
@@ -244,9 +244,8 @@ class StripeTerminalReactNative: RCTEventEmitter, DiscoveryDelegate, MobileReade
     func setConnectionToken(params: NSDictionary, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
         let token = params["token"] as? String
         let error = params["error"] as? String
-        let callbackId = params["callbackId"] as? String
 
-        TokenProvider.shared.setConnectionToken(token: token, error: error, callbackId: callbackId)
+        TokenProvider.shared.setConnectionToken(token: token, error: error)
         resolve([:])
     }
 

--- a/ios/Tests/TokenProviderTests.swift
+++ b/ios/Tests/TokenProviderTests.swift
@@ -1,0 +1,117 @@
+import XCTest
+
+@testable import stripe_terminal_react_native
+import StripeTerminal
+
+final class TokenProviderTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testNormalFlow() {
+        let tokenProvider = TokenProvider()
+        let expectation = self.expectation(description: "callback called")
+        var token: String? = nil
+        var error: Error? = nil
+      
+        let completion: ConnectionTokenCompletionBlock = { result, e in
+            token = result
+            error = e
+            expectation.fulfill()
+        }
+        tokenProvider.fetchConnectionToken(completion)
+        tokenProvider.setConnectionToken(token: "123456", error: nil)
+        waitForExpectations(timeout: 2.0) { e in
+          XCTAssertEqual(token, "123456")
+          XCTAssertNil(error)
+          XCTAssertEqual(tokenProvider.queue.count, 0)
+        }
+    }
+  
+    func testErrorFlow() {
+        let tokenProvider = TokenProvider()
+        let expectation = self.expectation(description: "callback called")
+        var token: String? = nil
+        var error: Error? = nil
+      
+        let completion: ConnectionTokenCompletionBlock = { result, e in
+            token = result
+            error = e
+            expectation.fulfill()
+        }
+        tokenProvider.fetchConnectionToken(completion)
+        tokenProvider.setConnectionToken(token: nil, error: "failed")
+        waitForExpectations(timeout: 2.0) { e in
+          XCTAssertNotNil(error)
+          XCTAssertNil(token)
+          XCTAssertEqual(tokenProvider.queue.count, 0)
+        }
+    }
+
+    func testMultipleRequestFlow() {
+        let tokenProvider = TokenProvider()
+        let expectation = self.expectation(description: "callback called")
+        expectation.expectedFulfillmentCount = 2
+        var token: String? = nil
+        var error: Error? = nil
+        var token2: String? = nil
+        var error2: Error? = nil
+      
+        let completion: ConnectionTokenCompletionBlock = { result, e in
+            token = result
+            error = e
+            expectation.fulfill()
+        }
+        let completion2: ConnectionTokenCompletionBlock = { result, e in
+            token2 = result
+            error2 = e
+            expectation.fulfill()
+        }
+        tokenProvider.fetchConnectionToken(completion)
+        tokenProvider.fetchConnectionToken(completion2)
+        tokenProvider.setConnectionToken(token: "123456", error: nil)
+        waitForExpectations(timeout: 2.0) { e in
+          XCTAssertEqual(token, "123456")
+          XCTAssertEqual(token2, "123456")
+          XCTAssertNil(error)
+          XCTAssertNil(error2)
+          XCTAssertEqual(tokenProvider.queue.count, 0)
+        }
+    }
+  
+    func testMultipleRequestFailFlow() {
+        let tokenProvider = TokenProvider()
+        let expectation = self.expectation(description: "callback called")
+        expectation.expectedFulfillmentCount = 2
+        var token: String? = nil
+        var error: Error? = nil
+        var token2: String? = nil
+        var error2: Error? = nil
+      
+        let completion: ConnectionTokenCompletionBlock = { result, e in
+            token = result
+            error = e
+            expectation.fulfill()
+        }
+        let completion2: ConnectionTokenCompletionBlock = { result, e in
+            token2 = result
+            error2 = e
+            expectation.fulfill()
+        }
+        tokenProvider.fetchConnectionToken(completion)
+        tokenProvider.fetchConnectionToken(completion2)
+        tokenProvider.setConnectionToken(token: "", error: "failed")
+        waitForExpectations(timeout: 2.0) { e in
+          XCTAssertNotNil(error)
+          XCTAssertNotNil(error2)
+          XCTAssertNil(token)
+          XCTAssertNil(token2)
+          XCTAssertEqual(tokenProvider.queue.count, 0)
+        }
+    }
+}

--- a/ios/ThreadSafeQueue.swift
+++ b/ios/ThreadSafeQueue.swift
@@ -3,7 +3,7 @@ class ThreadSafeQueue<T> {
     private let queue = DispatchQueue(label: "com.stripe.threadSafeQueue")
 
     func enqueue(_ element: T) {
-        queue.async {
+        queue.sync {
             self.array.append(element)
         }
     }

--- a/ios/ThreadSafeQueue.swift
+++ b/ios/ThreadSafeQueue.swift
@@ -1,6 +1,6 @@
 class ThreadSafeQueue<T> {
     private var array: [T] = []
-    private let queue = DispatchQueue(label: "com.stripe.threadSafeQueue")
+    private let queue = DispatchQueue(label: "com.stripe.terminal.reactnative.threadSafeQueue")
 
     func enqueue(_ element: T) {
         queue.sync {

--- a/ios/ThreadSafeQueue.swift
+++ b/ios/ThreadSafeQueue.swift
@@ -1,0 +1,28 @@
+class ThreadSafeQueue<T> {
+    private var array: [T] = []
+    private let queue = DispatchQueue(label: "com.stripe.threadSafeQueue")
+
+    func enqueue(_ element: T) {
+        queue.async {
+            self.array.append(element)
+        }
+    }
+
+    func dequeue() -> T? {
+        var element: T?
+        queue.sync {
+            if !self.array.isEmpty {
+                element = self.array.removeFirst()
+            }
+        }
+        return element
+    }
+
+    var isEmpty: Bool {
+        return queue.sync { self.array.isEmpty }
+    }
+
+    var count: Int {
+        return queue.sync { self.array.count }
+    }
+}

--- a/ios/TokenProvider.swift
+++ b/ios/TokenProvider.swift
@@ -12,11 +12,10 @@ class TokenProvider: ConnectionTokenProvider {
     func setConnectionToken(token: String?, error: String?) {
         while (!queue.isEmpty) {
             let completionCallback = queue.dequeue()
-            let unwrappedToken = token ?? ""
-            if (!unwrappedToken.isEmpty) {
+            if let unwrappedToken = token, !unwrappedToken.isEmpty {
                 completionCallback?(unwrappedToken, nil)
             } else {
-                completionCallback?(nil, TokenError.runtimeError(error ?? "Token is invalid"))
+              completionCallback?(nil, TokenError.runtimeError(error ?? "Token is invalid"))
             }
         }
     }

--- a/src/components/StripeTerminalProvider.tsx
+++ b/src/components/StripeTerminalProvider.tsx
@@ -295,17 +295,13 @@ export function StripeTerminalProvider({
   useListener(REPORT_READER_EVENT, didReportReaderEvent);
   useListener(ACCEPT_TERMS_OF_SERVICE, didAcceptTermsOfService);
 
-  const tokenProviderHandler = async ({
-    callbackId,
-  }: {
-    callbackId: string;
-  }) => {
+  const tokenProviderHandler = async () => {
     try {
       const connectionToken = await tokenProvider();
 
-      setConnectionToken(connectionToken, undefined, callbackId);
+      setConnectionToken(connectionToken, undefined);
     } catch (error) {
-      setConnectionToken(undefined, TOKEN_PROVIDER_ERROR_MESSAGE, callbackId);
+      setConnectionToken(undefined, TOKEN_PROVIDER_ERROR_MESSAGE);
 
       console.error(error);
       console.error(TOKEN_PROVIDER_ERROR_MESSAGE);

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -71,11 +71,10 @@ export async function initialize(
 
 export async function setConnectionToken(
   token?: string,
-  error?: string,
-  callbackId?: string
+  error?: string
 ): Promise<void> {
   try {
-    await StripeTerminalSdk.setConnectionToken({ token, error, callbackId });
+    await StripeTerminalSdk.setConnectionToken({ token, error });
   } catch (e) {
     console.warn('Unexpected error:', e);
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,7 +15,6 @@ export type InitParams = {
 export type SetConnectionTokenParams = {
   token?: string;
   error?: string;
-  callbackId?: string;
 };
 
 export type LogLevel = LogLevelIOS | LogLevelAndroid;
@@ -93,9 +92,9 @@ export type StripeError<T = CommonError> = {
 
 export type InitializeResultType =
   | {
-      reader?: Reader.Type;
-      error?: undefined;
-    }
+    reader?: Reader.Type;
+    error?: undefined;
+  }
   | { error: StripeError; reader?: undefined };
 
 export type DiscoverReadersResultType = Promise<{
@@ -108,9 +107,9 @@ export type CancelDiscoveringResultType = Promise<{
 
 export type ConnectReaderResultType =
   | {
-      reader: Reader.Type;
-      error?: undefined;
-    }
+    reader: Reader.Type;
+    error?: undefined;
+  }
   | { reader?: undefined; error: StripeError };
 
 export type DisconnectReaderResultType = {
@@ -261,39 +260,39 @@ export type CreateSetupIntentParams = {
 
 export type PaymentIntentResultType =
   | {
-      paymentIntent: PaymentIntent.Type;
-      error?: undefined;
-    }
+    paymentIntent: PaymentIntent.Type;
+    error?: undefined;
+  }
   | {
-      paymentIntent?: undefined;
-      error: StripeError;
-    }
+    paymentIntent?: undefined;
+    error: StripeError;
+  }
   | {
-      paymentIntent: PaymentIntent.Type;
-      error: StripeError;
-    };
+    paymentIntent: PaymentIntent.Type;
+    error: StripeError;
+  };
 
 export type SetupIntentResultType =
   | {
-      setupIntent: SetupIntent.Type;
-      error?: undefined;
-    }
+    setupIntent: SetupIntent.Type;
+    error?: undefined;
+  }
   | {
-      setupIntent?: undefined;
-      error: StripeError;
-    };
+    setupIntent?: undefined;
+    error: StripeError;
+  };
 
 export type GetLocationsResultType =
   | {
-      locations: Location[];
-      hasMore: boolean;
-      error?: undefined;
-    }
+    locations: Location[];
+    hasMore: boolean;
+    error?: undefined;
+  }
   | {
-      locations?: undefined;
-      hasMore?: undefined;
-      error: StripeError;
-    };
+    locations?: undefined;
+    hasMore?: undefined;
+    error: StripeError;
+  };
 
 export type ClearReaderDisplayResultType = {
   error: StripeError;
@@ -469,13 +468,13 @@ export namespace PaymentMethod {
 
 export type PaymentMethodResultType =
   | {
-      paymentMethod?: PaymentMethod.Type;
-      error: undefined;
-    }
+    paymentMethod?: PaymentMethod.Type;
+    error: undefined;
+  }
   | {
-      paymentMethod: undefined;
-      error: StripeError;
-    };
+    paymentMethod: undefined;
+    error: StripeError;
+  };
 
 export interface ICollectInputsParameters {
   inputs: Array<IInput>;
@@ -622,13 +621,13 @@ export enum CollectDataType {
 
 export type CollectDataResultType =
   | {
-      collectedData?: CollectedData;
-      error?: undefined;
-    }
+    collectedData?: CollectedData;
+    error?: undefined;
+  }
   | {
-      collectedData?: undefined;
-      error: StripeError;
-    };
+    collectedData?: undefined;
+    error: StripeError;
+  };
 
 export type TapToPayUxConfiguration = {
   tapZone?: TapZone;


### PR DESCRIPTION
## Summary

Change token callback usage and functionality

## Motivation

This is an improvement of https://github.com/stripe/stripe-terminal-react-native/pull/791 where we want to get rid of `setConnectionToken requires the callbackId to be set to the callbackId value provided to the tokenProviderHandler.` error been throw which related to https://github.com/stripe/stripe-terminal-react-native/issues/979

The existing token flow will act like:
1. TokenProvider.fetchConnectionToken request been called in Android with the callback function as variable
1. Create a key-value pair store into callbackMap with a random callbackId as key in TokenProvider for later use
1. Send FETCH_TOKEN_PROVIDER event from Android to RN with callbackId
1. Receive FETCH_TOKEN_PROVIDER notification in RN and fetchToken in RN layer
1. Send new token with callbackId back to Android via setConnectionToken function bridge
1. Fetch callback via callbackId and use callback to send token to native SDK
1. Remove the callback associate with callbackId

But the callbackId is useless given the token is fresh and didn't need to tie to the original request.
In this pr we change the Map of callbackId -> callback into thread safe queue where we resolve token request when first token response come and maintain the same availability as well as maintain the same request order. 

The proposed flow will act like:

1. TokenProvider.fetchConnectionToken request been called in Android with the callback function as variable
1. Store callback into queue in TokenProvider for later use
1. Send FETCH_TOKEN_PROVIDER event from Android to RN
1. Receive FETCH_TOKEN_PROVIDER notification in RN and fetchToken in RN layer
1. Send new token back to Android via setConnectionToken function bridge
1. Remove callback from queue and send token to native SDK via the callback

This can also solve some edge cases where:
- setConnectionToken didn't called due to token request timeout or other reason
- setConnectionToken for some reason been called twice or more where we don't have the callback linked after the first time

Note: Since it 's much low level and fundamental part, would like to change on Android only first and adopt to iOS later to limit the scope.

## Testing

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
