### PR TITLE
Fix the issue that reconnected alert freezes the HomeScreen

### DIFF
--- a/dev-app/src/screens/HomeScreen.tsx
+++ b/dev-app/src/screens/HomeScreen.tsx
@@ -1,9 +1,5 @@
-import React, { useEffect, useState, useContext, useCallback } from 'react';
-import {
-  useNavigation,
-  type NavigationProp,
-  useFocusEffect,
-} from '@react-navigation/native';
+import React, { useEffect, useState, useContext } from 'react';
+import { useNavigation, type NavigationProp } from '@react-navigation/native';
 import Toast from 'react-native-root-toast';
 import {
   StyleSheet,
@@ -168,14 +164,6 @@ export default function HomeScreen() {
     : '';
   const chargingStatus = connectedReader?.isCharging ? '🔌' : '';
   const deviceType = connectedReader?.deviceType;
-
-  useFocusEffect(
-    useCallback(() => {
-      return () => {
-        setShowDisconnectAlert({ visible: false });
-      };
-    }, [])
-  );
 
   useEffect(() => {
     const loadDiscSettings = async () => {

--- a/dev-app/src/screens/HomeScreen.tsx
+++ b/dev-app/src/screens/HomeScreen.tsx
@@ -40,7 +40,6 @@ export default function HomeScreen() {
   const [simulated, setSimulated] = useState<boolean>(true);
   const [simulatedOffline, setSimulatedOffline] = useState<boolean>(false);
   const [online, setOnline] = useState<boolean>(true);
-  // Disconnection alerts use AlertDialog, reconnection alerts use native Alert to avoid Modal conflicts
   const [showDisconnectAlert, setShowDisconnectAlert] = useState<{
     visible: boolean;
     reason?: string;
@@ -170,12 +169,9 @@ export default function HomeScreen() {
   const chargingStatus = connectedReader?.isCharging ? '🔌' : '';
   const deviceType = connectedReader?.deviceType;
 
-  // Reset AlertDialog states when screen loses focus to prevent issues when returning from other screens
   useFocusEffect(
     useCallback(() => {
-      // This runs when the screen comes into focus
       return () => {
-        // This cleanup runs when the screen loses focus
         setShowDisconnectAlert({ visible: false });
       };
     }, [])


### PR DESCRIPTION
## Summary

<!-- Simple summary of what was changed. -->
#### Problem
- AlertDialog caused complete UI freeze when navigating from CollectPaymentScreen → HomeScreen (**iOS only**).   

#### Root Cause
Modal's event handling mechanism broke due to timing mismatch:   
1. Wrong Timing: onDidSucceedReaderReconnect callback triggered during navigation
2. State Update: setShowReconnectSuccessAlert(true) called before HomeScreen fully ready
3. Broken Modal: Modal rendered but event listeners not properly bound
4. Event Black Hole: Modal intercepted all touch events but couldn't respond
5. UI Freeze: Entire interface became unresponsive

#### Solution
I am not sure how to avoid it by using State and AlertDialog, hence i replaced AlertDialog with native Alert.alert():
1. Bypasses React Modal system entirely
2. No dependency on component lifecycle timing
3. Platform-native event handling


## Motivation

<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

In our dev-app, the custom reconnecting and reconnected alert dialogs might freeze the HomeScreen when HomeScreen integrates with other screens.

## Testing

<!-- Did you test your changes? Ideally you should check both of the following boxes. -->

- [X] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [X] This PR does not result in any developer-facing changes.
