### PR TITLE
Move @testing-library/react-native to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@react-native/metro-config": "^0.78.0",
     "@react-native/typescript-config": "0.78.0",
     "@rnx-kit/align-deps": "^3.0.5",
+    "@testing-library/react-native": "^12.4.0",
     "@types/base-64": "^1.0.0",
     "@types/jest": "^29.5.11",
     "@types/react": "^18.2.6",
@@ -184,7 +185,6 @@
     ]
   },
   "dependencies": {
-    "@testing-library/react-native": "^12.4.0",
     "base-64": "^1.0.0",
     "react-native-gradle-plugin": "^0.71.19"
   },


### PR DESCRIPTION
## Summary

Currently, despite being only used as a dev dependency (for tests), `@testing-library/react-native` is installed a dependency, creating an useless warning when we install the library:

<img width="895" height="271" alt="Screenshot 2025-09-23 at 15 26 12" src="https://github.com/user-attachments/assets/27e725cc-0089-4670-a4e2-12ef3f81a72e" />

This PR moves the dep to devDeps.

## Motivation

<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a link to the relevant issue, a code snippet, or an example project that demonstrates the bug. -->

## Testing

- [x] I tested this manually
- [ ] I added automated tests

## Documentation

Select one:

- [ ] I have added relevant documentation for my changes.
- [x] This PR does not result in any developer-facing changes.
